### PR TITLE
k8s integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+test: fetch-pr test-kubernetes
+
+.PHONY: fetch-pr
+fetch-pr:
+
+	# Get coredns code
+	mkdir -p ${GOPATH}/src/${COREDNSPATH}
+	cd ${GOPATH}/src/${COREDNSPATH} && \
+	  git clone https://${COREDNSREPO}/coredns.git && \
+	  cd coredns && \
+	  git fetch --depth 1 origin pull/${PR}/head:pr-${PR} && \
+	  git checkout pr-${PR}
+
+.PHONY: test-kubernetes
+test-kubernetes:
+	# Start local docker image repo (k8s must pull images from a repo)
+	-docker run -d -p 5000:5000 --restart=always --name registry registry:2.6.2 || true
+
+	# Build coredns docker image, and push to local repo
+	cd ${GOPATH}/src/${COREDNSPATH}/coredns && \
+	  ${MAKE} coredns SYSTEM="GOOS=linux" && \
+	  docker build -t coredns . && \
+	  docker tag coredns localhost:5000/coredns && \
+	  docker push localhost:5000/coredns
+
+	# Set up minikube
+	-sh ./build/kubernetes/minikube_setup.sh
+
+	# Do tests
+	go test -v -tags 'k8s' ./test/kubernetes/...
+
+.PHONY: clean-kubernetes
+clean-kubernetes:
+	# Clean up
+	-sh ./build/kubernetes/minikube_teardown.sh
+
+.PHONY: install-webhook
+install-webhook:
+	cp ./build/pr-comment-hook.sh /opt/bin/
+	# For now, update /etc/webhook.conf and /etc/caddy/Caddyfile are manual
+
+PHONY: install-minikube
+install-minikube:
+	# Install minikube
+	sh ./build/kubernetes/minikube_install.sh
+

--- a/build/kubernetes/coredns.yaml
+++ b/build/kubernetes/coredns.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        kubernetes cluster.local 10.0.0.0/8
+    }
+  Zonefile: |
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: coredns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: coredns
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      containers:
+      - name: coredns
+        image: localhost:5000/coredns
+        imagePullPolicy: Always
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+            - key: Zonefile
+              path: Zonefile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: coredns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: coredns
+  clusterIP: 10.0.0.10
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP

--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -1,0 +1,199 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-2
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: de-1-a
+  namespace: test-1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: app-1-a
+    spec:
+      containers:
+      - name: app-1-a-c
+        image: gcr.io/google_containers/pause-amd64:3.0
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 443
+          name: https
+          protocol: TCP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: de-1-b
+  namespace: test-1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: app-1-b
+    spec:
+      containers:
+      - name: app-1-b-c
+        image: gcr.io/google_containers/pause-amd64:3.0
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: de-c
+  namespace: test-1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: app-c
+    spec:
+      containers:
+      - name: app-c-c
+        image: gcr.io/google_containers/pause-amd64:3.0
+        ports:
+        - containerPort: 1234
+          name: c-port
+          protocol: UDP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: de-c
+  namespace: test-2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: app-c
+    spec:
+      containers:
+      - name: app-c-c
+        image: gcr.io/google_containers/pause-amd64:3.0
+        ports:
+        - containerPort: 1234
+          name: c-port
+          protocol: UDP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: de-d1
+  namespace: test-1
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: app-d
+    spec:
+      containers:
+      - name: app-d-c
+        image: gcr.io/google_containers/pause-amd64:3.0
+        ports:
+        - containerPort: 1234
+          name: c-port
+          protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-1-a
+  namespace: test-1
+spec:
+  selector:
+    app: app-1-a
+  clusterIP: 10.0.0.100
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: https
+    port: 443
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-1-b
+  namespace: test-1
+spec:
+  selector:
+    app: app-1-b
+  clusterIP: 10.0.0.110
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-c
+  namespace: test-1
+spec:
+  selector:
+    app: app-c
+  clusterIP: 10.0.0.115
+  ports:
+  - name: c-port
+    port: 1234
+    protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-c
+  namespace: test-2
+spec:
+  selector:
+    app: app-c
+  clusterIP: 10.0.0.120
+  ports:
+  - name: c-port
+    port: 1234
+    protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc
+  namespace: test-1
+spec:
+  selector:
+    app: app-d
+  clusterIP: None
+  ports:
+  - name: c-port
+    port: 1234
+    protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ext-svc
+  namespace: test-1
+spec:
+  type: ExternalName
+  externalName: example.net
+  ports:
+  - name: c-port
+    port: 1234
+    protocol: UDP
+

--- a/build/kubernetes/hyperkube_setup.sh
+++ b/build/kubernetes/hyperkube_setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+KUBECTL="docker exec hyperkube /hyperkube kubectl"
+
+# Start hyperkube container
+docker run -d \
+    --volume=/:/rootfs:ro \
+    --volume=/sys:/sys:ro \
+    --volume=/var/lib/docker/:/var/lib/docker:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/run:/var/run:rw \
+    --volume=`pwd`/.travis:/travis \
+    --net=host --pid=host --privileged \
+    --name=hyperkube gcr.io/google_containers/hyperkube-amd64:$K8S_VERSION \
+    /hyperkube \
+    kubelet \
+        --containerized \
+        --hostname-override=127.0.0.1 \
+        --api-servers=http://localhost:8080 \
+        --config=/etc/kubernetes/manifests \
+        --allow-privileged --v=2
+
+# Wait until kubectl is ready
+for i in {1..10}; do $KUBECTL version && break || sleep 5; done
+
+# Set up kubectl config context
+$KUBECTL config set-cluster test-doc --server=http://localhost:8080
+$KUBECTL config set-context test-doc --cluster=test-doc
+$KUBECTL config use-context test-doc
+
+# Wait until k8s api is ready
+for i in {1..30}; do $KUBECTL get nodes && break || sleep 5; done
+
+# Create test objects
+$KUBECTL create -f /travis/kubernetes/dns-test.yaml
+

--- a/build/kubernetes/minikube_install.sh
+++ b/build/kubernetes/minikube_install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -v
+
+# Install minikube and kubectl
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube
+curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl
+mv ./minikube /usr/local/bin/
+mv ./kubectl /usr/local/bin/
+
+# Start a local docker repository
+docker run -d -p 5000:5000 --restart=always --name registry registry:2.6.2

--- a/build/kubernetes/minikube_setup.sh
+++ b/build/kubernetes/minikube_setup.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -v
+
+ci_bin=$GOPATH/src/github.com/coredns/ci/build
+
+# Start local docker image repository
+docker run -d -p 5000:5000 --restart=always --name registry registry:2.6.2
+
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+mkdir $HOME/.kube || true
+touch $HOME/.kube/config
+
+export KUBECONFIG=$HOME/.kube/config
+if [[ -z ${K8S_VERSION} ]]; then
+  minikube start --vm-driver=none
+else
+  minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
+fi
+
+# Wait for kubernetes api service to be ready
+for i in {1..60} # timeout for 2 minutes
+do
+   kubectl get po
+   if [ $? -ne 1 ]; then
+      break
+  fi
+  sleep 2
+done
+
+# Disable kube-dns in addon manager
+minikube addons disable kube-dns
+
+# Deploy test objects
+kubectl create -f ${ci_bin}/kubernetes/dns-test.yaml
+
+# Deploy coredns in place of kube-dns
+kubectl apply -f ${ci_bin}/kubernetes/coredns.yaml
+
+# Wait for coredns to be ready
+for i in {1..60} # timeout for 2 minutes
+do
+  kubectl -n kube-system get pods | grep coredns
+  kubectl -n kube-system get pods | grep coredns | grep Running && break
+  sleep 2
+done
+
+# Wait for all test pods in test-1 to be ready (there are 5)
+for i in {1..60} # timeout for 2 minutes
+do
+  if [ $(kubectl -n test-1 get pods | grep Running | wc -l) = "5" ]; then
+    break
+  fi
+  sleep 2
+done
+
+# Give coredns a chance to load the pods/svcs into api cache
+sleep 3
+

--- a/build/kubernetes/minikube_teardown.sh
+++ b/build/kubernetes/minikube_teardown.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PR=$1
+
+# delete minikube instance
+minikube delete
+
+# Delete the docker image repository
+docker stop registry
+docker rm registry

--- a/build/pr-comment-hook.sh
+++ b/build/pr-comment-hook.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -e
+export COREDNSFORK='coredns'
+export COREDNSPROJ='coredns'
+export COREDNSREPO="github.com/${COREDNSFORK}"
+export COREDNSPATH="github.com/${COREDNSPROJ}"
+export HOME=/root
+
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/root/go/bin
+
+export GHTOKEN=$(cat /root/.ghtoken)
+
+# We receive all json in one giant string in the env var $PAYLOAD.
+if [[ -z ${PAYLOAD} ]]; then
+    exit 1
+fi
+
+# Only trigger on comment creation
+action=$(echo ${PAYLOAD} | jq '.action' | tr -d "\n\"")
+if [[ "${action}" != "created" ]]; then
+    exit 0
+fi
+
+# PRs are Issues with a pull_request section.
+# If there is no pull_request section, then this is not a PR, we can exit
+pull_url=$(echo ${PAYLOAD} | jq '.issue.pull_request.url' | tr -d "\n\"")
+if [[ -z ${pull_url} ]]; then
+    exit 0
+fi
+
+# Get the PR number
+export PR=$(echo ${PAYLOAD} | jq '.issue.number' | tr -d "\n\"")
+
+# Create temporary workspace and set GOPATH
+workdir=$(mktemp -d)
+export GOPATH=$workdir
+
+# Set up a clean up on exit
+function rmWorkdir {
+    rm -rf ${workdir}
+}
+trap rmWorkdir EXIT
+
+function postStatus {
+    body=$1
+    curl --user $GHTOKEN -X POST --data "{\"body\":\"$body\"}" https://api.github.com/repos/${COREDNSFORK}/${COREDNSPROJ}/issues/${PR}/comments | jq '.id'
+}
+
+function updateStatus {
+    body=$1
+    curl --user $GHTOKEN -X POST --data "{\"body\":\"$body\"}" https://api.github.com/repos/${COREDNSFORK}/${COREDNSPROJ}/issues/comments/${STATUSID}
+}
+
+function lockFail {
+    updateStatus "Integration test could not start. (timeout waiting for lock)"
+    exit 1
+}
+
+# Get the contents of the comment
+body=$(echo ${PAYLOAD} | jq '.comment.body' | tr -d "\n\"")
+case "${body}" in
+    */integration*)
+    export STATUSID=$(postStatus "Integration test request received.")
+
+    # Check lock
+    exec 9>/var/lock/integration-test
+    flock -w 300 9 || lockFail
+
+    # Setup log and post status + log link to PR
+    touch /var/www/log/${PR}.txt  2>&1
+    echo "############### Integration Test ${COREDNSREPO}:PR${PR} #######################" > /var/www/log/${PR}.txt
+    chown www-data: /var/www/log/${PR}.txt 2>&1
+    updateStatus "Integration test started. <a href='https://drone.coredns.io/log/view.html?pr=${PR}'>View Log</a>"
+
+    # Get ci code
+    mkdir -p ${GOPATH}/src/${COREDNSPATH}
+    cd ${GOPATH}/src/${COREDNSPATH}
+    git clone https://${COREDNSREPO}/ci.git
+    cd ci
+    git fetch --depth 1 origin pull/2/head:pr-2
+    git checkout pr-2
+
+	# Set up a finish & clean up on exit
+    function finishIntegrationTest {
+        make clean-kubernetes >> /var/www/log/${PR}.txt 2>&1
+        # Post result to pr
+        pass=$(cat /var/www/log/${PR}.txt | grep "^\-\-\- PASS:" | wc -l)
+        fail=$(cat /var/www/log/${PR}.txt | grep "^\-\-\- FAIL:" | wc -l)
+        subpass=$(cat /var/www/log/${PR}.txt | grep "^    \-\-\- PASS:" | wc -l)
+        subfail=$(cat /var/www/log/${PR}.txt | grep "^    \-\-\- FAIL:" | wc -l)
+        if [[ "${fail}" != "0" ]]; then
+            summary="FAIL"
+        fi
+        printf -v summary '\\n\\n
+        |          | Pass   | Fail   |\\n
+        | -------- | ------ | ------ |\\n
+        | Tests    | %s     | %s     |\\n
+        | Subtests | %s     | %s     |\\n' "${pass}" "${fail}" "${subpass}" "${subfail}"
+        summary=$(echo $summary | tr -d '\n')
+        updateStatus "Integration test $status. <a href='https://drone.coredns.io/log/view.html?pr=${PR}'>View Log</a> $summary"
+        rmWorkdir
+    }
+    trap finishIntegrationTest EXIT
+
+    # Do integration setup and test
+    export K8S_VERSION='v1.7.5'
+    status="FAIL"
+    make test >> /var/www/log/${PR}.txt 2>&1 && status="PASS"
+
+  ;;
+esac

--- a/build/view.html
+++ b/build/view.html
@@ -1,0 +1,79 @@
+<html>
+<head>
+    <script type="text/javascript">
+        function createRequestObject() {
+
+            var req;
+
+            if(window.XMLHttpRequest){
+                // Firefox, Safari, Opera...
+                req = new XMLHttpRequest();
+            } else if(window.ActiveXObject) {
+                // Internet Explorer 5+
+                req = new ActiveXObject("Microsoft.XMLHTTP");
+            } else {
+                // There is an error creating the object,
+                // just as an old browser is being used.
+                alert('There was a problem creating the XMLHttpRequest object');
+            }
+            return req;
+        }
+
+        // Make the XMLHttpRequest object
+        var http = createRequestObject();
+
+        function sendRequest() {
+            var pr = getParameterByName("pr")
+            var timestamp = new Date();
+            http.open('get', '/log/'+pr+'.txt?t='+timestamp);
+            http.onreadystatechange = handleResponse;
+            http.send(null);
+        }
+
+        function handleResponse() {
+            if(http.readyState == 4 && http.status == 200){
+                var response = http.responseText;
+                if(response) {
+                    document.getElementById("log").innerHTML = response;
+                    if (document.getElementById("followcheck").checked) {
+                        window.scrollTo(0,document.body.scrollHeight);
+                    }
+                    setTimeout(update,1000);
+                }
+            }
+        }
+
+        function update() {
+            sendRequest();
+        }
+
+        function getParameterByName(name) {
+            var url = window.location.href;
+            name = name.replace(/[\[\]]/g, "\\$&");
+            var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+                results = regex.exec(url);
+            if (!results) return null;
+            if (!results[2]) return '';
+            return decodeURIComponent(results[2].replace(/\+/g, " "));
+        }
+
+        function stopFollow(){
+            // Stop following the log if user scrolls off the bottom of the window
+            if (window.scrollY < document.body.scrollHeight - window.innerHeight){
+                document.getElementById("followcheck").checked = false
+            }
+        }
+        function startFollow(){
+            window.scrollTo(0,document.body.scrollHeight);
+            document.getElementById("followcheck").checked = true
+        }
+
+    </script>
+</head>
+<body onLoad="sendRequest()" onscroll="stopFollow()"/>
+<span style="position:fixed;top:2%;right:2%"> <input type="checkbox"  checked="true" onclick="startFollow()" id="followcheck" title="follow log"/> follow </span>
+<pre>
+<span id="log" name="log"></span>
+</pre>
+</body>
+</html>

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -1,0 +1,173 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestAuto(t *testing.T) {
+	t.Parallel()
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	corefile := `org:0 {
+		auto {
+			directory ` + tmpdir + ` db\.(.*) {1} 1
+		}
+	}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "www.example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("Expected reply to be a SERVFAIL, got %d", resp.Rcode)
+	}
+
+	// Write db.example.org to get example.org.
+	if err = ioutil.WriteFile(path.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(1500 * time.Millisecond) // wait for it to be picked up
+
+	resp, err = p.Lookup(state, "www.example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("Expected 1 RR in the answer section, got %d", len(resp.Answer))
+	}
+
+	// Remove db.example.org again.
+	os.Remove(path.Join(tmpdir, "db.example.org"))
+
+	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+	resp, err = p.Lookup(state, "www.example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("Expected reply to be a SERVFAIL, got %d", resp.Rcode)
+	}
+}
+
+func TestAutoNonExistentZone(t *testing.T) {
+	t.Parallel()
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.SetOutput(ioutil.Discard)
+
+	corefile := `.:0 {
+		auto {
+			directory ` + tmpdir + ` (.*) {1} 1
+		}
+		errors stdout
+	}
+`
+
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatal("Could not get UDP listening port")
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("Expected reply to be a SERVFAIL, got %d", resp.Rcode)
+	}
+}
+
+func TestAutoAXFR(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	corefile := `org:0 {
+		auto {
+			directory ` + tmpdir + ` db\.(.*) {1} 1
+			transfer to *
+		}
+	}
+`
+
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatal("Could not get UDP listening port")
+	}
+	defer i.Stop()
+
+	// Write db.example.org to get example.org.
+	if err = ioutil.WriteFile(path.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+
+	p := proxy.NewLookup([]string{udp})
+	m := new(dns.Msg)
+	m.SetAxfr("example.org.")
+	state := request.Request{W: &test.ResponseWriter{}, Req: m}
+
+	resp, err := p.Lookup(state, "example.org.", dns.TypeAXFR)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	if len(resp.Answer) != 5 {
+		t.Fatalf("Expected response with %d RRs, got %d", 5, len(resp.Answer))
+	}
+}
+
+const zoneContent = `; testzone
+@	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082534 7200 3600 1209600 3600
+		NS	a.iana-servers.net.
+		NS	b.iana-servers.net.
+
+www IN A 127.0.0.1
+`

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestLookupCache(t *testing.T) {
+	// Start auth. CoreDNS holding the auth zone.
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	// Start caching proxy CoreDNS that we want to test.
+	corefile = `example.org:0 {
+	proxy . ` + udp + `
+	cache 10
+}
+`
+	i, udp, _, err = CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect answer section with A record in it
+	if len(resp.Answer) == 0 {
+		t.Fatal("Expected to at least one RR in the answer section, got none")
+	}
+
+	ttl := resp.Answer[0].Header().Ttl
+	if ttl != 10 { // as set in the Corefile
+		t.Errorf("Expected TTL to be %d, got %d", 10, ttl)
+	}
+}

--- a/test/chaos_test.go
+++ b/test/chaos_test.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	// Plug in CoreDNS, needed for AppVersion and AppName in this test.
+	_ "github.com/coredns/coredns/coremain"
+
+	"github.com/mholt/caddy"
+	"github.com/miekg/dns"
+)
+
+func TestChaos(t *testing.T) {
+	corefile := `.:0 {
+		chaos
+}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	m := new(dns.Msg)
+	m.SetQuestion("version.bind.", dns.TypeTXT)
+	m.Question[0].Qclass = dns.ClassCHAOS
+
+	resp, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %v", err)
+	}
+	chTxt := resp.Answer[0].(*dns.TXT).Txt[0]
+	version := caddy.AppName + "-" + caddy.AppVersion
+	if chTxt != version {
+		t.Fatalf("Expected version to bo %s, got %s", version, chTxt)
+	}
+}

--- a/test/doc.go
+++ b/test/doc.go
@@ -1,0 +1,2 @@
+// Package test contains function and types useful for writing tests
+package test

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -1,0 +1,65 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	mtest "github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Using miek.nl here because this is the easiest zone to get access to and it's masters
+// run both NSD and BIND9, making checks like "what should we actually return" super easy.
+var dsTestCases = []mtest.Case{
+	{
+		Qname: "_udp.miek.nl.", Qtype: dns.TypeDS,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			mtest.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
+	{
+		Qname: "miek.nl.", Qtype: dns.TypeDS,
+		Ns: []dns.RR{
+			mtest.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
+}
+
+func TestLookupDS(t *testing.T) {
+	t.Parallel()
+	name, rm, err := TempFile(".", miekNL)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `miek.nl:0 {
+       file ` + name + `
+}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &mtest.ResponseWriter{}, Req: new(dns.Msg)}
+
+	for _, tc := range dsTestCases {
+		resp, err := p.Lookup(state, tc.Qname, tc.Qtype)
+		if err != nil || resp == nil {
+			t.Fatalf("Expected to receive reply, but didn't for %s %d", tc.Qname, tc.Qtype)
+		}
+
+		mtest.SortAndCheck(t, resp, tc)
+	}
+}

--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -1,0 +1,80 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestLookupAutoPathErratic(t *testing.T) {
+	corefile := `.:0 {
+	erratic
+	autopath @erratic
+	proxy . 8.8.8.8:53
+	debug
+    }
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	tests := []struct {
+		qname          string
+		expectedAnswer string
+		expectedType   uint16
+	}{
+		{"google.com.a.example.org.", "google.com.a.example.org.", dns.TypeCNAME},
+		{"google.com.", "google.com.", dns.TypeA},
+	}
+
+	for i, tc := range tests {
+		m := new(dns.Msg)
+		// erratic always returns this search path: "a.example.org.", "b.example.org.", "".
+		m.SetQuestion(tc.qname, dns.TypeA)
+
+		r, err := dns.Exchange(m, udp)
+		if err != nil {
+			t.Fatalf("Test %d, failed to sent query: %q", i, err)
+		}
+		if len(r.Answer) == 0 {
+			t.Fatalf("Test %d, answer section should have RRs", i)
+		}
+		if x := r.Answer[0].Header().Name; x != tc.expectedAnswer {
+			t.Fatalf("Test %d, expected answer %s, got %s", i, tc.expectedAnswer, x)
+		}
+		if x := r.Answer[0].Header().Rrtype; x != tc.expectedType {
+			t.Fatalf("Test %d, expected answer type %d, got %d", i, tc.expectedType, x)
+		}
+	}
+}
+
+func TestAutoPathErraticNotLoaded(t *testing.T) {
+	corefile := `.:0 {
+	autopath @erratic
+	proxy . 8.8.8.8:53
+	debug
+    }
+`
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+	defer i.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("google.com.a.example.org.", dns.TypeA)
+	r, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Failed to sent query: %q", err)
+	}
+	if r.Rcode != dns.RcodeNameError {
+		t.Fatalf("Expected NXDOMAIN, got %d", r.Rcode)
+	}
+}

--- a/test/etcd_cache_test.go
+++ b/test/etcd_cache_test.go
@@ -1,0 +1,77 @@
+// +build etcd
+
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+// uses some stuff from etcd_tests.go
+
+func TestEtcdCache(t *testing.T) {
+	corefile := `.:0 {
+    etcd skydns.test {
+        path /skydns
+    }
+    cache skydns.test
+}`
+
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer ex.Stop()
+
+	etc := etcdPlugin()
+	log.SetOutput(ioutil.Discard)
+
+	var ctx = context.TODO()
+	for _, serv := range servicesCacheTest {
+		set(ctx, t, etc, serv.Key, 0, serv)
+		defer delete(ctx, t, etc, serv.Key)
+	}
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "b.example.skydns.test.", dns.TypeA)
+	if err != nil {
+		t.Errorf("Expected to receive reply, but didn't: %s", err)
+	}
+	checkResponse(t, resp)
+
+	resp, err = p.Lookup(state, "b.example.skydns.test.", dns.TypeA)
+	if err != nil {
+		t.Errorf("Expected to receive reply, but didn't: %s", err)
+	}
+	checkResponse(t, resp)
+	if len(resp.Extra) != 0 {
+		t.Errorf("Expected no RRs in additional section, got: %d", len(resp.Extra))
+	}
+}
+
+func checkResponse(t *testing.T, resp *dns.Msg) {
+	if len(resp.Answer) == 0 {
+		t.Fatal("Expected to at least one RR in the answer section, got none")
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
+var servicesCacheTest = []*msg.Service{
+	{Host: "127.0.0.1", Port: 666, Key: "b.example.skydns.test."},
+}

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -1,0 +1,104 @@
+// +build etcd
+
+package test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/etcd"
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	etcdc "github.com/coreos/etcd/client"
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+func etcdPlugin() *etcd.Etcd {
+	etcdCfg := etcdc.Config{
+		Endpoints: []string{"http://localhost:2379"},
+	}
+	cli, _ := etcdc.New(etcdCfg)
+	client := etcdc.NewKeysAPI(cli)
+	return &etcd.Etcd{Client: client, PathPrefix: "/skydns"}
+}
+
+// This test starts two coredns servers (and needs etcd). Configure a stubzones in both (that will loop) and
+// will then test if we detect this loop.
+func TestEtcdStubLoop(t *testing.T) {
+	// TODO(miek)
+}
+
+func TestEtcdStubAndProxyLookup(t *testing.T) {
+	corefile := `.:0 {
+    etcd skydns.local {
+        stubzones
+        path /skydns
+        endpoint http://localhost:2379
+        upstream 8.8.8.8:53 8.8.4.4:53
+	fallthrough
+    }
+    proxy . 8.8.8.8:53
+}`
+
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer ex.Stop()
+
+	etc := etcdPlugin()
+	log.SetOutput(ioutil.Discard)
+
+	var ctx = context.TODO()
+	for _, serv := range servicesStub { // adds example.{net,org} as stubs
+		set(ctx, t, etc, serv.Key, 0, serv)
+		defer delete(ctx, t, etc, serv.Key)
+	}
+
+	p := proxy.NewLookup([]string{udp}) // use udp port from the server
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "example.com.", dns.TypeA)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %v", err)
+	}
+	if len(resp.Answer) == 0 {
+		t.Fatalf("Expected to at least one RR in the answer section, got none")
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "93.184.216.34" {
+		t.Errorf("Expected 93.184.216.34, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
+var servicesStub = []*msg.Service{
+	// Two tests, ask a question that should return servfail because remote it no accessible
+	// and one with edns0 option added, that should return refused.
+	{Host: "127.0.0.1", Port: 666, Key: "b.example.org.stub.dns.skydns.test."},
+	// Actual test that goes out to the internet.
+	{Host: "199.43.132.53", Key: "a.example.net.stub.dns.skydns.test."},
+}
+
+// Copied from plugin/etcd/setup_test.go
+func set(ctx context.Context, t *testing.T, e *etcd.Etcd, k string, ttl time.Duration, m *msg.Service) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
+	e.Client.Set(ctx, path, string(b), &etcdc.SetOptions{TTL: ttl})
+}
+
+// Copied from plugin/etcd/setup_test.go
+func delete(ctx context.Context, t *testing.T, e *etcd.Etcd, k string) {
+	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
+	e.Client.Delete(ctx, path, &etcdc.DeleteOptions{Recursive: false})
+}

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -1,0 +1,14 @@
+package test
+
+const exampleOrg = `; example.org test file
+example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+example.org.		IN	NS	b.iana-servers.net.
+example.org.		IN	NS	a.iana-servers.net.
+example.org.		IN	A	127.0.0.1
+example.org.		IN	A	127.0.0.2
+*.w.example.org.        IN      TXT     "Wildcard"
+a.b.c.w.example.org.    IN      TXT     "Not a wildcard"
+cname.example.org.      IN      CNAME   www.example.net.
+
+service.example.org.    IN      SRV     8080 10 10 example.org.
+`

--- a/test/external_test.go
+++ b/test/external_test.go
@@ -1,0 +1,72 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Go get external example plugin, compile it into CoreDNS
+// and check if it is really there, but running coredns -plugins.
+
+// Dangerous test as it messes with your git tree, maybe use tag?
+func testExternalPluginCompile(t *testing.T) {
+	if err := addExamplePlugin(); err != nil {
+		t.Fatal(err)
+	}
+	defer run(t, gitReset)
+
+	if _, err := run(t, goGet); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run(t, goGen); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run(t, goBuild); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, coredns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(out), "dns.example") {
+		t.Fatal("dns.example plugin should be there")
+	}
+}
+
+func run(t *testing.T, c *exec.Cmd) ([]byte, error) {
+	c.Dir = ".."
+	out, err := c.Output()
+	if err != nil {
+		return nil, fmt.Errorf("run: failed to run %s %s: %q", c.Args[0], c.Args[1], err)
+	}
+	return out, nil
+
+}
+
+func addExamplePlugin() error {
+	f, err := os.OpenFile("../plugin.cfg", os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(example)
+	return err
+}
+
+var (
+	goBuild  = exec.Command("go", "build")
+	goGen    = exec.Command("go", "generate")
+	goGet    = exec.Command("go", "get", "github.com/coredns/example")
+	gitReset = exec.Command("git", "checkout", "core/*")
+	coredns  = exec.Command("./coredns", "-plugins")
+)
+
+const example = "1001:example:github.com/coredns/example"

--- a/test/file.go
+++ b/test/file.go
@@ -1,0 +1,19 @@
+package test
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// TempFile will create a temporary file on disk and returns the name and a cleanup function to remove it later.
+func TempFile(dir, content string) (string, func(), error) {
+	f, err := ioutil.TempFile(dir, "go-test-tmpfile")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := ioutil.WriteFile(f.Name(), []byte(content), 0644); err != nil {
+		return "", nil, err
+	}
+	rmFunc := func() { os.Remove(f.Name()) }
+	return f.Name(), rmFunc, nil
+}

--- a/test/file_cname_proxy_test.go
+++ b/test/file_cname_proxy_test.go
@@ -1,0 +1,84 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestZoneExternalCNAMELookupWithoutProxy(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	name, rm, err := TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "cname.example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+	// There should only be a CNAME in the answer section.
+	if len(resp.Answer) != 1 {
+		t.Fatalf("Expected 1 RR in answer section got %d", len(resp.Answer))
+	}
+}
+
+func TestZoneExternalCNAMELookupWithProxy(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	name, rm, err := TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+       file ` + name + ` {
+	       upstream 8.8.8.8
+	}
+}
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "cname.example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+	// There should be a CNAME *and* an IP address in the answer section.
+	// For now, just check that we have 2 RRs
+	if len(resp.Answer) != 2 {
+		t.Fatalf("Expected 2 RRs in answer section got %d", len(resp.Answer))
+	}
+}

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -1,0 +1,71 @@
+package test
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/file"
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestZoneReload(t *testing.T) {
+	file.TickTime = 1 * time.Second
+
+	name, rm, err := TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with two stanzas
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+
+example.net:0 {
+	file ` + name + `
+}
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+	if len(resp.Answer) != 2 {
+		t.Fatalf("Expected two RR in answer section got %d", len(resp.Answer))
+	}
+
+	// Remove RR from the Apex
+	ioutil.WriteFile(name, []byte(exampleOrgUpdated), 0644)
+
+	time.Sleep(2 * time.Second) // reload time
+
+	resp, err = p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+
+	if len(resp.Answer) != 1 {
+		t.Fatalf("Expected two RR in answer section got %d", len(resp.Answer))
+	}
+}
+
+const exampleOrgUpdated = `; example.org test file
+example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082541 7200 3600 1209600 3600
+example.org.		IN	NS	b.iana-servers.net.
+example.org.		IN	NS	a.iana-servers.net.
+example.org.		IN	A	127.0.0.2
+`

--- a/test/file_srv_additional_test.go
+++ b/test/file_srv_additional_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestZoneSRVAdditional(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	name, rm, err := TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "service.example.org.", dns.TypeSRV)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	// There should be 2 A records in the additional section.
+	if len(resp.Extra) != 2 {
+		t.Fatalf("Expected 2 RR in additional section got %d", len(resp.Extra))
+	}
+}

--- a/test/file_test.go
+++ b/test/file_test.go
@@ -1,0 +1,12 @@
+package test
+
+import "testing"
+
+func TestTempFile(t *testing.T) {
+	t.Parallel()
+	_, f, e := TempFile(".", "test")
+	if e != nil {
+		t.Fatalf("failed to create temp file: %s", e)
+	}
+	defer f()
+}

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"github.com/coredns/coredns/pb"
+)
+
+func TestGrpc(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	corefile := `grpc://.:0 {
+		whoami
+}
+`
+	g, _, tcp, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer g.Stop()
+
+	conn, err := grpc.Dial(tcp, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5*time.Second))
+	if err != nil {
+		t.Fatalf("Expected no error but got: %s", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewDnsServiceClient(conn)
+
+	m := new(dns.Msg)
+	m.SetQuestion("whoami.example.org.", dns.TypeA)
+	msg, _ := m.Pack()
+
+	reply, err := client.Query(context.TODO(), &pb.DnsPacket{Msg: msg})
+	if err != nil {
+		t.Errorf("Expected no error but got: %s", err)
+	}
+
+	d := new(dns.Msg)
+	err = d.Unpack(reply.Msg)
+	if err != nil {
+		t.Errorf("Expected no error but got: %s", err)
+	}
+
+	if d.Rcode != dns.RcodeSuccess {
+		t.Errorf("Expected success but got %d", d.Rcode)
+	}
+
+	if len(d.Extra) != 2 {
+		t.Errorf("Expected 2 RRs in additional section, but got %d", len(d.Extra))
+	}
+}

--- a/test/health_reload_test.go
+++ b/test/health_reload_test.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"testing"
+)
+
+func TestHealthReload(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+	health localhost:35080
+}
+`
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	resp, err := http.Get("http://localhost:35080/health")
+	if err != nil {
+		t.Fatalf("Could not get health: %s", err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if x := string(body); x != "OK" {
+		t.Fatalf("Expect OK, got %s", x)
+	}
+	resp.Body.Close()
+
+	i, err = i.Restart(NewInput(corefile))
+	if err != nil {
+		t.Fatalf("Could not restart CoreDNS serving instance: %s", err)
+	}
+
+	defer i.Stop()
+
+	resp, err = http.Get("http://localhost:35080/health")
+	if err != nil {
+		t.Fatalf("Could not get health: %s", err)
+	}
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Could not get resp.Body: %s", err)
+	}
+	if x := string(body); x != "OK" {
+		t.Fatalf("Expect OK, got %s", x)
+	}
+	resp.Body.Close()
+}

--- a/test/hosts_file_test.go
+++ b/test/hosts_file_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestHostsInlineLookup(t *testing.T) {
+	corefile := `example.org:0 {
+                       hosts highly_unlikely_to_exist_hosts_file example.org {
+                         10.0.0.1 example.org
+                         fallthrough
+                      }	
+                    }`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect answer section with A record in it
+	if len(resp.Answer) == 0 {
+		t.Fatal("Expected to at least one RR in the answer section, got none")
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "10.0.0.1" {
+		t.Errorf("Expected 10.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}

--- a/test/kubernetes/a_test.go
+++ b/test/kubernetes/a_test.go
@@ -1,0 +1,99 @@
+// +build k8s
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsTestCasesA = []test.Case{
+	{ // An A record query for an existing service should return a record
+		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.      5    IN      A       10.0.0.100"),
+		},
+	},
+	{ // An A record query for an existing headless service should return a record for each of its endpoints
+		Qname: "headless-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeSuccess,
+		Answer: headlessAResponse("headless-svc.test-1.svc.cluster.local.", "headless-svc", "test-1"),
+	},
+	{ // An A record query for a non-existing service should return NXDOMAIN
+		Qname: "bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{ // An A record query for a non-existing endpoint should return NXDOMAIN
+		Qname: "bogusendpoint.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{ // A service record search with a wild card namespace should return all (1) services in exposed namespaces
+		Qname: "svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-1-a.*.svc.cluster.local.      303    IN      A       10.0.0.100"),
+		},
+	},
+	{ // A wild card service name in an exposed namespace should result in all records
+		Qname: "*.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: append([]dns.RR{
+			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.110"),
+			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.115"),
+			test.CNAME("*.test-1.svc.cluster.local.  303    IN	     CNAME	  example.net."),
+			test.A("example.net.		303	IN	A	13.14.15.16"),
+		}, headlessAResponse("*.test-1.svc.cluster.local.", "headless-svc", "test-1")...),
+	},
+	{ // A wild card service name in an un-exposed namespace result in nxdomain
+		Qname: "*.test-2.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{ // By default, pod queries are disabled, so a pod query should return a server failure
+		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeServerFailure,
+	},
+	{ // A TXT request for dns-version should return the version of the kubernetes service discovery spec implemented
+		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.TXT(`dns-version.cluster.local. 303 IN TXT "1.0.1"`),
+		},
+	},
+}
+
+func TestKubernetesA(t *testing.T) {
+
+	rmFunc, upstream, udp := upstreamServer(t, "example.net", exampleNet)
+	defer upstream.Stop()
+	defer rmFunc()
+
+	corefile := `    .:53 {
+        errors
+        log
+        kubernetes cluster.local 10.in-addr.arpa {
+            namespaces test-1
+            upstream ` + udp + `
+        }
+    }
+`
+
+	err := loadCorefile(corefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+	doIntegrationTests(t, dnsTestCasesA, "test-1")
+}

--- a/test/kubernetes/autopath_test.go
+++ b/test/kubernetes/autopath_test.go
@@ -1,0 +1,100 @@
+// +build k8s
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var autopathTests = []test.Case{
+	{ // Valid service name -> success on 1st search in path -> A record
+		Qname: "svc-1-a", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+		},
+	},
+	{ // Valid service name + namespace -> success on 2nd search in path -> CNAME glue + A record
+		Qname: "svc-1-a.test-1", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("svc-1-a.test-1.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+		},
+	},
+	{ // Valid service name + namespace + svc -> success on 3nd search in path -> CNAME glue + A record
+		Qname: "svc-1-a.test-1.svc", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("svc-1-a.test-1.svc.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+		},
+	},
+	{ // Valid fqdn for internal service -> success on empty search -> CNAME glue + A record
+		Qname: "svc-1-a.test-1.svc.cluster.local", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("svc-1-a.test-1.svc.cluster.local.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+		},
+	},
+	{ // Valid external fqdn -> success on empty search -> CNAME glue + A record
+		Qname: "foo.example.net", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("foo.example.net.test-1.svc.cluster.local.  303    IN	     CNAME	  foo.example.net."),
+			test.A("foo.example.net.      303    IN      A       10.10.10.11"),
+		},
+		Ns: []dns.RR{
+			test.NS("example.net.	303	IN	NS	ns.example.net."),
+		},
+	},
+	/*
+		{ // prevent client search on query fail - this optimization is not implemented
+			Qname: "bar.example.net", Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+		},
+	*/
+}
+
+func TestKubernetesAutopath(t *testing.T) {
+
+	// set up server to handle internal zone, to trap *.internal search path in travis environment.
+	internal := `; internal zone info for autopath tests
+internal.		IN	SOA	sns.internal. noc.internal. 2015082541 7200 3600 1209600 3600
+`
+	rmFunc, upstream, udp := upstreamServer(t, "internal", internal)
+	defer upstream.Stop()
+	defer rmFunc()
+
+	corefile :=
+		`    .:53 {
+      errors
+      log
+      autopath @kubernetes
+      kubernetes cluster.local {
+        pods verified
+      }
+      file /etc/coredns/Zonefile example.net
+      proxy internal ` + udp + `
+    }
+`
+	exampleZonefile := `    ; example.net zone info for autopath tests
+    example.net.		IN	SOA	sns.example.net. noc.example.net. 2015082541 7200 3600 1209600 3600
+    example.net.		IN	NS	ns.example.net.
+    example.net.      IN      A	10.10.10.10
+    foo.example.net.      IN      A	10.10.10.11
+
+`
+	err := loadCorefileAndZonefile(corefile, exampleZonefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile/zonefile: %s", err)
+	}
+
+	doIntegrationTests(t, autopathTests, "test-1")
+
+}

--- a/test/kubernetes/excluster_test.go
+++ b/test/kubernetes/excluster_test.go
@@ -1,0 +1,52 @@
+// +build k8sexclust
+
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/test"
+	intTest "github.com/coredns/coredns/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestKubernetesAPIFallthrough(t *testing.T) {
+	tests := []test.Case{
+		{
+			Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			},
+		},
+	}
+
+	corefile :=
+		`.:0 {
+    kubernetes cluster.local {
+        endpoint nonexistance:8080,invalidip:8080,localhost:8080
+    }`
+
+	server, udp, _, err := intTest.CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer server.Stop()
+
+	// Work-around for timing condition that results in no-data being returned in test environment.
+	time.Sleep(3 * time.Second)
+
+	for _, tc := range tests {
+
+		c := new(dns.Client)
+		m := tc.Msg()
+
+		res, _, err := c.Exchange(m, udp)
+		if err != nil {
+			t.Fatalf("Could not send query: %s", err)
+		}
+		test.SortAndCheck(t, res, tc)
+	}
+}

--- a/test/kubernetes/fallthrough_test.go
+++ b/test/kubernetes/fallthrough_test.go
@@ -1,0 +1,91 @@
+// +build k8s
+
+package kubernetes
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+var dnsTestCasesFallthrough = []test.Case{
+	{
+		Qname: "ext-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("example.net.		303	IN	A	13.14.15.16"),
+			test.CNAME("ext-svc.test-1.svc.cluster.local. 303 IN	CNAME	example.net."),
+		},
+	},
+	{
+		Qname: "f.b.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("f.b.svc.cluster.local.      303    IN      A       10.10.10.11"),
+		},
+		Ns: []dns.RR{
+			test.NS("cluster.local.	303	IN	NS	a.iana-servers.net."),
+			test.NS("cluster.local.	303	IN	NS	b.iana-servers.net."),
+		},
+	},
+	{
+		Qname: "foo.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("foo.cluster.local.      303    IN      A       10.10.10.10"),
+		},
+		Ns: []dns.RR{
+			test.NS("cluster.local.	303	IN	NS	a.iana-servers.net."),
+			test.NS("cluster.local.	303	IN	NS	b.iana-servers.net."),
+		},
+	},
+}
+
+func TestKubernetesFallthrough(t *testing.T) {
+
+	rmFunc, upstream, udp := upstreamServer(t, "example.net", exampleNet)
+	defer upstream.Stop()
+	defer rmFunc()
+
+	time.Sleep(1 * time.Second)
+
+	corefile := `    .:53 {
+	  errors
+	  log
+      file /etc/coredns/Zonefile cluster.local
+      kubernetes cluster.local {
+          namespaces test-1
+          upstream ` + udp + `
+          fallthrough
+      }
+    }
+`
+	err := loadCorefileAndZonefile(corefile, clusterLocal)
+	if err != nil {
+		t.Fatalf("Could not load corefile/zonefile: %s", err)
+	}
+	doIntegrationTests(t, dnsTestCasesFallthrough, "test-1")
+}
+
+const clusterLocal = `    ; cluster.local test file for fallthrough
+    cluster.local.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+    cluster.local.		IN	NS	b.iana-servers.net.
+    cluster.local.		IN	NS	a.iana-servers.net.
+    cluster.local.		IN	A	127.0.0.1
+    cluster.local.		IN	A	127.0.0.2
+    foo.cluster.local.      IN      A	10.10.10.10
+    f.b.svc.cluster.local.  IN      A	10.10.10.11
+    *.w.cluster.local.      IN      TXT     "Wildcard"
+    a.b.svc.cluster.local.  IN      TXT     "Not a wildcard"
+    cname.cluster.local.    IN      CNAME   www.example.net.
+    service.namespace.svc.cluster.local.    IN      SRV     8080 10 10 cluster.local.
+`

--- a/test/kubernetes/helpers.go
+++ b/test/kubernetes/helpers.go
@@ -1,0 +1,424 @@
+// +build k8s k8sexclust
+
+package kubernetes
+
+import (
+	"bufio"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+	intTest "github.com/coredns/coredns/test"
+
+	"errors"
+	"fmt"
+	"github.com/mholt/caddy"
+	"github.com/miekg/dns"
+	"io/ioutil"
+	"time"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+// doIntegrationTests executes test cases
+func doIntegrationTests(t *testing.T, testCases []test.Case, namespace string) {
+
+	clientName := "coredns-test-client"
+	err := startClientPod(namespace, clientName)
+	if err != nil {
+		t.Fatalf("failed to start client pod: %s", err)
+	}
+	for _, tc := range testCases {
+
+		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
+
+			digCmd := "dig -t " + dns.TypeToString[tc.Qtype] + " " + tc.Qname + " +search +showsearch +time=10 +tries=6"
+
+			// attach to client and execute query.
+			var cmdout string
+			tries := 3
+			for {
+				cmdout, err = kubectl("-n " + namespace + " exec " + clientName + " -- " + digCmd)
+				if err == nil {
+					break
+				}
+				tries = tries - 1
+				if tries == 0 {
+					t.Errorf("failed to execute query '%s' got error: '%s'", digCmd, err)
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+			results, err := ParseDigResponse(cmdout)
+			if err != nil {
+				t.Errorf("failed to parse result: (%s) '%s'", err, cmdout)
+			}
+			if len(results) != 1 {
+				t.Errorf("expected 1 query attempt, observed %v", len(results))
+			}
+			res := results[0]
+
+			// Before sort and check, make sure that CNAMES do not appear after their target records.
+			test.CNAMEOrder(t, res)
+
+			sort.Sort(test.RRSet(tc.Answer))
+			sort.Sort(test.RRSet(tc.Ns))
+			sort.Sort(test.RRSet(tc.Extra))
+			test.SortAndCheck(t, res, tc)
+
+			if t.Failed() {
+				t.Errorf("coredns log: %s", corednsLogs())
+			}
+		})
+	}
+}
+
+func startClientPod(namespace, clientName string) error {
+	_, err := kubectl("-n " + namespace + " run " + clientName + " --image=infoblox/dnstools --restart=Never -- -c 'while [ 1 ]; do sleep 100; done'")
+	if err != nil {
+		// ignore error (pod already running)
+		return nil
+	}
+	maxWait := 60 // 60 seconds
+	for {
+		o, _ := kubectl("-n " + namespace + "  get pod " + clientName)
+		if strings.Contains(o, "Running") {
+			return nil
+		}
+		time.Sleep(time.Second)
+		maxWait = maxWait - 1
+		if maxWait == 0 {
+			break
+		}
+	}
+	return errors.New("timeout waiting for " + clientName + " to be ready.")
+
+}
+
+// upstreamServer starts a local instance of coredns with the given zone file
+func upstreamServer(t *testing.T, zone, zoneFile string) (func(), *caddy.Instance, string) {
+	upfile, rmFunc, err := intTest.TempFile(os.TempDir(), zoneFile)
+	if err != nil {
+		t.Fatalf("could not create file for CNAME upstream lookups: %s", err)
+	}
+	upstreamCorefile := `.:0 {
+    file ` + upfile + ` ` + zone + `
+    bind ` + locaIP().String() + `
+}`
+	server, udp, _, err := intTest.CoreDNSServerAndPorts(upstreamCorefile)
+	if err != nil {
+		t.Fatalf("could not get CoreDNS serving instance: %s", err)
+	}
+
+	return rmFunc, server, udp
+}
+
+// localIP returns the local system's first ipv4 non-loopback address
+func locaIP() net.IP {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	for _, addr := range addrs {
+		ip, _, _ := net.ParseCIDR(addr.String())
+		ip = ip.To4()
+		if ip == nil || ip.IsLoopback() {
+			continue
+		}
+		return ip
+	}
+	return nil
+}
+
+// headlessAResponse returns the answer to an A request for the specific name and namespace.
+func headlessAResponse(qname, name, namespace string) []dns.RR {
+	rr := []dns.RR{}
+
+	str, err := endpointIPs(name, namespace)
+	if err != nil {
+		log.Fatal("error running kubectl command: ", err.Error())
+	}
+	result := strings.Split(string(str), " ")
+	lr := len(result)
+
+	for i := 0; i < lr; i++ {
+		rr = append(rr, test.A(qname+"    303    IN      A   "+result[i]))
+	}
+	return rr
+}
+
+// srvResponse returns the answer to a SRV request for the specific name and namespace
+// qtype is the type of answer to generate, eg: TypeSRV (for answer section) or TypeA (for extra section).
+func srvResponse(qname string, qtype uint16, name, namespace string) []dns.RR {
+	rr := []dns.RR{}
+
+	str, err := endpointIPs(name, namespace)
+
+	if err != nil {
+		log.Fatal("error running kubectl command: ", err.Error())
+	}
+	result := strings.Split(string(str), " ")
+	lr := len(result)
+
+	for i := 0; i < lr; i++ {
+		ip := strings.Replace(result[i], ".", "-", -1)
+		t := strconv.Itoa(100 / (lr + 1))
+
+		switch qtype {
+		case dns.TypeA:
+			rr = append(rr, test.A(ip+"."+name+"."+namespace+".svc.cluster.local.	303	IN	A	"+result[i]))
+		case dns.TypeSRV:
+			if name == "headless-svc" {
+				rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 1234  "+ip+"."+name+"."+namespace+".svc.cluster.local."))
+			} else {
+				rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 443  "+ip+"."+name+"."+namespace+".svc.cluster.local."))
+				rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 80  "+ip+"."+name+"."+namespace+".svc.cluster.local."))
+			}
+		}
+	}
+	return rr
+}
+
+//endpointIPs retrieves the IP address for a given name and namespace by parsing json using kubectl command
+func endpointIPs(name, namespace string) (cmdOut []byte, err error) {
+	cmdout, err := kubectl(string(" -n " + namespace + " get endpoints " + name + " -o jsonpath={.subsets[*].addresses[*].ip}"))
+	return []byte(cmdout), err
+}
+
+// loadCorefile calls loadCorefileAndZonefile
+func loadCorefile(corefile string) error {
+	return loadCorefileAndZonefile(corefile, "")
+}
+
+// loadCorefileAndZonefile constructs and configmap defining files for the corefile and zone,
+// forces the coredns pod to load the new configmap, and waits for the coredns pod to be ready.
+func loadCorefileAndZonefile(corefile, zonefile string) error {
+
+	// apply configmap yaml
+	yamlString := configmap + "\n"
+	yamlString += "  Corefile: |\n" + prepForConfigMap(corefile)
+	yamlString += "  Zonefile: |\n" + prepForConfigMap(zonefile)
+
+	file, rmFunc, err := intTest.TempFile(os.TempDir(), yamlString)
+	if err != nil {
+		return err
+	}
+	defer rmFunc()
+	_, err = kubectl("apply -f " + file)
+	if err != nil {
+		return err
+	}
+
+	// force coredns pod reload the config
+	kubectl("-n kube-system delete pods -l k8s-app=coredns")
+
+	// wait for coredns to be ready before continuing
+	maxWait := 30 // 15 seconds (each failed check sleeps 0.5 seconds)
+	running := 0
+	for {
+		o, _ := kubectl("-n kube-system get pods -l k8s-app=coredns")
+		if strings.Contains(o, "Running") {
+			running += 1
+		}
+		if running >= 2 {
+			// give coredns a chance to read its config before declaring victory
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+		maxWait = maxWait - 1
+		if maxWait == 0 {
+			//println(o)
+			logs := corednsLogs()
+			return errors.New("timeout waiting for coredns to be ready. coredns log: " + logs)
+		}
+	}
+	return nil
+}
+
+func corednsLogs() string {
+	name, _ := kubectl("-n kube-system get pods -l k8s-app=coredns | grep Running | cut -f1 -d' ' | tr -d '\n'")
+	logs, _ := kubectl("-n kube-system logs " + name)
+	return (logs)
+}
+
+// prepForConfigMap returns a config prepared for inclusion in a configmap definition
+func prepForConfigMap(config string) string {
+	var configOut string
+	lines := strings.Split(config, "\n")
+	for _, line := range lines {
+		// replace all tabs with spaces
+		line = strings.Replace(line, "\t", "  ", -1)
+		// indent line with 4 addtl spaces
+		configOut += "    " + line + "\n"
+	}
+	return configOut
+}
+
+// kubectl executes the kubectl command with the given arguments
+func kubectl(args string) (result string, err error) {
+	kctl := os.Getenv("KUBECTL")
+
+	if kctl == "" {
+		kctl = "kubectl"
+	}
+	cmdOut, err := exec.Command("sh", "-c", kctl+" "+args).CombinedOutput()
+	if err != nil {
+		return "", errors.New("got error '" + string(cmdOut) + "' for command " + kctl + " " + args)
+	}
+	return string(cmdOut), nil
+}
+
+// ParseDigResponse parses dig-like command output and returns a dns.Msg
+func ParseDigResponse(r string) ([]*dns.Msg, error) {
+	s := bufio.NewScanner(strings.NewReader(r))
+	var msgs []*dns.Msg
+	var err error
+
+	for err == nil {
+		m, err := parseDig(s)
+		if err != nil {
+			break
+		}
+		msgs = append(msgs, m)
+	}
+
+	if len(msgs) == 0 {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+// parseDig parses a single dig-like response and returns a dns.Msg
+func parseDig(s *bufio.Scanner) (*dns.Msg, error) {
+	m := new(dns.Msg)
+	err := parseDigHeader(s, m)
+	if err != nil {
+		return nil, err
+	}
+	err = parseDigQuestion(s, m)
+	if err != nil {
+		return nil, err
+	}
+	err = parseDigSections(s, m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func parseDigHeader(s *bufio.Scanner, m *dns.Msg) error {
+	headerSection := ";; ->>HEADER<<- "
+	for {
+		if strings.HasPrefix(s.Text(), headerSection) {
+			break
+		}
+		if !s.Scan() {
+			return errors.New("header section not found")
+		}
+	}
+	l := s.Text()
+	strings.Replace(l, headerSection, "", 1)
+	nvps := strings.Split(l, ", ")
+	for _, nvp := range nvps {
+		nva := strings.Split(nvp, ": ")
+		if nva[0] == "opcode" {
+			m.Opcode = invertIntMap(dns.OpcodeToString)[nva[1]]
+		}
+		if nva[0] == "status" {
+			m.Rcode = invertIntMap(dns.RcodeToString)[nva[1]]
+		}
+		if nva[0] == "id" {
+			i, err := strconv.Atoi(nva[1])
+			if err != nil {
+				return err
+			}
+			m.MsgHdr.Id = uint16(i)
+		}
+	}
+	return nil
+}
+
+func parseDigQuestion(s *bufio.Scanner, m *dns.Msg) error {
+	for {
+		if strings.HasPrefix(s.Text(), ";; QUESTION SECTION:") {
+			break
+		}
+		if !s.Scan() {
+			return errors.New("question section not found")
+		}
+	}
+	s.Scan()
+	l := s.Text()
+	l = strings.TrimLeft(l, ";")
+	fields := strings.Fields(l)
+	m.SetQuestion(fields[0], invertUint16Map(dns.TypeToString)[fields[2]])
+	return nil
+}
+
+func parseDigSections(s *bufio.Scanner, m *dns.Msg) error {
+	var section string
+	for s.Scan() {
+		if strings.HasSuffix(s.Text(), " SECTION:") {
+			section = strings.Fields(s.Text())[1]
+			continue
+		}
+		if s.Text() == "" {
+			continue
+		}
+		if strings.HasPrefix(s.Text(), ";;") {
+			break
+		}
+		r, err := dns.NewRR(s.Text())
+		if err != nil {
+			return err
+		}
+		if section == "ANSWER" {
+			m.Answer = append(m.Answer, r)
+		}
+		if section == "AUTHORITY" {
+			m.Ns = append(m.Ns, r)
+		}
+		if section == "ADDITIONAL" {
+			m.Extra = append(m.Extra, r)
+		}
+	}
+	return nil
+}
+
+func invertIntMap(m map[int]string) map[string]int {
+	n := make(map[string]int)
+	for k, v := range m {
+		n[v] = k
+	}
+	return n
+}
+
+func invertUint16Map(m map[uint16]string) map[string]uint16 {
+	n := make(map[string]uint16)
+	for k, v := range m {
+		n[v] = k
+	}
+	return n
+}
+
+
+// configmap is the header used for defining the coredns configmap
+const configmap = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:`
+
+// exampleNet is an example upstream zone file
+const exampleNet = `; example.net. test file for cname tests
+example.net.          IN      SOA     ns.example.net. admin.example.net. 2015082541 7200 3600 1209600 3600
+example.net. IN A 13.14.15.16
+`

--- a/test/kubernetes/helpers_test.go
+++ b/test/kubernetes/helpers_test.go
@@ -1,0 +1,95 @@
+// +build k8s k8sexclust
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/miekg/dns"
+)
+
+func TestParseDigResponse(t *testing.T) {
+
+	r := `; <<>> DiG 9.4.1-P1 <<>> mt-example.com
+;; global options:  printcmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 25550
+;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;svc-1-a.test-1.svc.cluster.local.			IN	A
+
+;; AUTHORITY SECTION:
+cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60
+
+;; Query time: 4 msec
+;; SERVER: 64.207.129.21#53(64.207.129.21)
+;; WHEN: Thu Aug  7 16:49:35 2008
+;; MSG SIZE  rcvd: 48
+
+
+; <<>> DiG 9.4.1-P1 <<>> mt-example.com
+;; global options:  printcmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25550
+;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 1, ADDITIONAL: 2
+
+;; QUESTION SECTION:
+;svc-1-a.test-1.svc.cluster.local.			IN	A
+
+;; ANSWER SECTION:
+cname.test-1.svc.cluster.local.		5	IN	CNAME	svc-1-a.test-1.svc.cluster.local.
+svc-1-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.100
+svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.101
+
+;; AUTHORITY SECTION:
+cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60
+
+;; ADDITIONAL SECTION:
+svc-1-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.100
+svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.101
+
+;; Query time: 4 msec
+;; SERVER: 64.207.129.21#53(64.207.129.21)
+;; WHEN: Thu Aug  7 16:49:35 2008
+;; MSG SIZE  rcvd: 48`
+
+	tcs := []test.Case{
+		{
+			Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeNameError,
+			Ns: []dns.RR{
+				test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+			},
+		}, {
+			Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.CNAME("cname.test-1.svc.cluster.local.      303    IN      CNAME       svc-1-a.test-1.svc.cluster.local."),
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+				test.A("svc-2-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.101"),
+			},
+			Ns: []dns.RR{
+				test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+			},
+			Extra: []dns.RR{
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+				test.A("svc-2-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.101"),
+			},
+		},
+	}
+
+	ms, err := ParseDigResponse(r)
+	if err != nil {
+		t.Fatalf("failed test: %s", err)
+	}
+
+	if len(ms) != 2 {
+		t.Fatalf("failed test: got %v results, expected 2", len(ms))
+	}
+
+	test.SortAndCheck(t, ms[0], tcs[0])
+	test.SortAndCheck(t, ms[1], tcs[1])
+
+}

--- a/test/kubernetes/nsexposure_test.go
+++ b/test/kubernetes/nsexposure_test.go
@@ -1,0 +1,43 @@
+// +build k8s
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsTestCasesAllNSExposed = []test.Case{
+	{
+		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+		},
+	},
+	{
+		Qname: "svc-c.test-2.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-c.test-2.svc.cluster.local.      303    IN      A       10.0.0.120"),
+		},
+	},
+}
+
+func TestKubernetesNSExposed(t *testing.T) {
+	corefile :=
+		`    .:53 {
+      errors
+      log
+      kubernetes cluster.local
+    }
+`
+	err := loadCorefile(corefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+	doIntegrationTests(t, dnsTestCasesAllNSExposed, "test-1")
+}

--- a/test/kubernetes/pods_test.go
+++ b/test/kubernetes/pods_test.go
@@ -1,0 +1,81 @@
+// +build k8s
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsTestCasesPodsInsecure = []test.Case{
+	{
+		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("10-20-0-101.test-1.pod.cluster.local. 303 IN A    10.20.0.101"),
+		},
+	},
+	{
+		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307903 7200 1800 86400 60"),
+		},
+	},
+}
+
+func TestKubernetesPodsInsecure(t *testing.T) {
+	corefile := `    .:53 {
+	  errors
+	  log
+      kubernetes cluster.local {
+                namespaces test-1
+                pods insecure
+      }
+    }
+`
+
+	err := loadCorefile(corefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+	doIntegrationTests(t, dnsTestCasesPodsInsecure, "test-1")
+
+}
+
+var dnsTestCasesPodsVerified = []test.Case{
+	{
+		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502308197 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307960 7200 1800 86400 60"),
+		},
+	},
+}
+
+func TestKubernetesPodsVerified(t *testing.T) {
+	corefile := `    .:53 {
+	  errors
+	  log
+      kubernetes cluster.local {
+                namespaces test-1
+                pods verified
+      }
+    }
+`
+	err := loadCorefile(corefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+	doIntegrationTests(t, dnsTestCasesPodsVerified, "test-1")
+}

--- a/test/kubernetes/srv_test.go
+++ b/test/kubernetes/srv_test.go
@@ -1,0 +1,170 @@
+// +build k8s
+
+package kubernetes
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+var dnsTestCasesSRV = []test.Case{
+	{
+		Qname: "*._TcP.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("*._TcP.svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	 0  50  443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("*._TcP.svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	 0  50   80 svc-1-a.test-1.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.	303 	IN	A	10.0.0.100"),
+		},
+	},
+	{
+		Qname: "*.*.bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "*.any.svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("*.any.svc-1-a.*.svc.cluster.local.      303    IN    SRV 0 50 443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("*.any.svc-1-a.*.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-a.test-1.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
+		},
+	},
+	{
+		Qname: "ANY.*.svc-1-a.any.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("ANY.*.svc-1-a.any.svc.cluster.local.      303    IN    SRV 0 50 443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("ANY.*.svc-1-a.any.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-a.test-1.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.	303 	IN	A	10.0.0.100"),
+		},
+	},
+	{
+		Qname: "*.*.bogusservice.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "*.*.bogusservice.any.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "_c-port._UDP.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeSRV, "headless-svc", "test-1"),
+			[]dns.RR{
+				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 33 1234 svc-c.test-1.svc.cluster.local.")}...),
+		Extra: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeA, "headless-svc", "test-1"),
+			[]dns.RR{
+				test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.0.0.115")}...),
+	},
+	{
+		Qname: "*._tcp.any.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("*._tcp.any.test-1.svc.cluster.local.      303    IN    SRV 0 33 443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("*._tcp.any.test-1.svc.cluster.local.      303    IN    SRV 0 33 80  svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("*._tcp.any.test-1.svc.cluster.local.      303    IN    SRV 0 33 80  svc-1-b.test-1.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
+			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.0.0.110"),
+		},
+	},
+	{
+		Qname: "*.*.any.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "*.*.*.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "_http._tcp.*.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.*.*.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_http._tcp.*.*.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-b.test-1.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
+			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.0.0.110"),
+		},
+	},
+	{
+		Qname: "*.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeSuccess,
+		Answer: srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeSRV, "svc-1-a", "test-1"),
+		Extra:  srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeA, "svc-1-a", "test-1"),
+	},
+	{
+		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	0 50 443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	0 50 80 svc-1-a.test-1.svc.cluster.local."),
+		},
+		Extra: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
+		},
+	},
+}
+
+func TestKubernetesSRV(t *testing.T) {
+
+	rmFunc, upstream, udp := upstreamServer(t, "example.net", exampleNet)
+	defer upstream.Stop()
+	defer rmFunc()
+
+	corefile := `    .:53 {
+	    errors
+	    log
+        kubernetes cluster.local {
+            namespaces test-1
+            upstream ` + udp + `
+        }
+    }
+`
+
+	err := loadCorefile(corefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+	doIntegrationTests(t, dnsTestCasesSRV, "test-1")
+}

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -1,0 +1,187 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/cache"
+	"github.com/coredns/coredns/plugin/metrics"
+	mtest "github.com/coredns/coredns/plugin/metrics/test"
+	"github.com/coredns/coredns/plugin/metrics/vars"
+
+	"github.com/miekg/dns"
+)
+
+// fail when done in parallel
+
+// Start test server that has metrics enabled. Then tear it down again.
+func TestMetricsServer(t *testing.T) {
+	corefile := `example.org:0 {
+	chaos CoreDNS-001 miek@miek.nl
+	prometheus localhost:0
+}
+
+example.com:0 {
+	proxy . 8.8.4.4:53
+	prometheus localhost:0
+}
+`
+	srv, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer srv.Stop()
+}
+
+func TestMetricsRefused(t *testing.T) {
+	metricName := "coredns_dns_response_rcode_count_total"
+
+	corefile := `example.org:0 {
+	proxy . 8.8.8.8:53
+	prometheus localhost:0
+}
+`
+	srv, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer srv.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("google.com.", dns.TypeA)
+
+	if _, err = dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	data := mtest.Scrape(t, "http://"+metrics.ListenAddr+"/metrics")
+	got, labels := mtest.MetricValue(metricName, data)
+
+	if got != "1" {
+		t.Errorf("Expected value %s for refused, but got %s", "1", got)
+	}
+	if labels["zone"] != vars.Dropped {
+		t.Errorf("Expected zone value %s for refused, but got %s", vars.Dropped, labels["zone"])
+	}
+	if labels["rcode"] != "REFUSED" {
+		t.Errorf("Expected zone value %s for refused, but got %s", "REFUSED", labels["rcode"])
+	}
+}
+
+// TODO(miek): disabled for now - fails in weird ways in travis.
+func testMetricsCache(t *testing.T) {
+	cacheSizeMetricName := "coredns_cache_size"
+	cacheHitMetricName := "coredns_cache_hits_total"
+
+	corefile := `www.example.net:0 {
+	proxy . 8.8.8.8:53
+	prometheus localhost:0
+	cache
+}
+`
+	srv, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer srv.Stop()
+
+	udp, _ := CoreDNSServerPorts(srv, 0)
+
+	m := new(dns.Msg)
+	m.SetQuestion("www.example.net.", dns.TypeA)
+
+	if _, err = dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	data := mtest.Scrape(t, "http://"+metrics.ListenAddr+"/metrics")
+	// Get the value for the cache size metric where the one of the labels values matches "success".
+	got, _ := mtest.MetricValueLabel(cacheSizeMetricName, cache.Success, data)
+
+	if got != "1" {
+		t.Errorf("Expected value %s for %s, but got %s", "1", cacheSizeMetricName, got)
+	}
+
+	// Second request for the same response to test hit counter.
+	if _, err = dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	data = mtest.Scrape(t, "http://"+metrics.ListenAddr+"/metrics")
+	// Get the value for the cache hit counter where the one of the labels values matches "success".
+	got, _ = mtest.MetricValueLabel(cacheHitMetricName, cache.Success, data)
+
+	if got != "2" {
+		t.Errorf("Expected value %s for %s, but got %s", "2", cacheHitMetricName, got)
+	}
+}
+
+func TestMetricsAuto(t *testing.T) {
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	corefile := `org:0 {
+		auto {
+			directory ` + tmpdir + ` db\.(.*) {1} 1
+		}
+		prometheus localhost:0
+	}
+`
+
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	// Write db.example.org to get example.org.
+	if err = ioutil.WriteFile(path.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// TODO(miek): make the auto sleep even less.
+	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+
+	m := new(dns.Msg)
+	m.SetQuestion("www.example.org.", dns.TypeA)
+
+	if _, err := dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	metricName := "coredns_dns_request_count_total" //{zone, proto, family}
+
+	data := mtest.Scrape(t, "http://"+metrics.ListenAddr+"/metrics")
+	// Get the value for the metrics where the one of the labels values matches "example.org."
+	got, _ := mtest.MetricValueLabel(metricName, "example.org.", data)
+
+	if got != "1" {
+		t.Errorf("Expected value %s for %s, but got %s", "1", metricName, got)
+	}
+
+	// Remove db.example.org again. And see if the metric stops increasing.
+	os.Remove(path.Join(tmpdir, "db.example.org"))
+	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+	if _, err := dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	data = mtest.Scrape(t, "http://"+metrics.ListenAddr+"/metrics")
+	got, _ = mtest.MetricValueLabel(metricName, "example.org.", data)
+
+	if got != "1" {
+		t.Errorf("Expected value %s for %s, but got %s", "1", metricName, got)
+	}
+}

--- a/test/middleware_dnssec_test.go
+++ b/test/middleware_dnssec_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
+	t.Parallel()
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+	rm1 := createKeyFile(t)
+	defer rm1()
+
+	corefile := `example.org:0 {
+    file ` + name + `
+    rewrite type ANY HINFO
+    dnssec {
+        key file ` + base + `
+    }
+    loadbalance
+}
+`
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer ex.Stop()
+
+	log.SetOutput(ioutil.Discard)
+	c := new(dns.Client)
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+	m.SetEdns0(4096, true)
+	res, _, err := c.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Could not send query: %s", err)
+	}
+	sig := 0
+	for _, a := range res.Answer {
+		if a.Header().Rrtype == dns.TypeRRSIG {
+			sig++
+		}
+	}
+	if sig == 0 {
+		t.Errorf("expected RRSIGs, got none")
+		t.Logf("%v\n", res)
+	}
+}
+
+func createKeyFile(t *testing.T) func() {
+	ioutil.WriteFile(base+".key",
+		[]byte(`example.org. IN DNSKEY 256 3 13 tDyI0uEIDO4SjhTJh1AVTFBLpKhY3He5BdAlKztewiZ7GecWj94DOodg ovpN73+oJs+UfZ+p9zOSN5usGAlHrw==`),
+		0644)
+	ioutil.WriteFile(base+".private",
+		[]byte(`Private-key-format: v1.3
+Algorithm: 13 (ECDSAP256SHA256)
+PrivateKey: HPmldSNfrkj/aDdUMFwuk/lgzaC5KIsVEG3uoYvF4pQ=
+Created: 20160426083115
+Publish: 20160426083115
+Activate: 20160426083115`),
+		0644)
+	return func() {
+		os.Remove(base + ".key")
+		os.Remove(base + ".private")
+	}
+}
+
+const base = "Kexample.org.+013+44563"

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func benchmarkLookupBalanceRewriteCache(b *testing.B) {
+	t := new(testing.T)
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+    file ` + name + `
+    rewrite type ANY HINFO
+    loadbalance
+}
+`
+
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer ex.Stop()
+
+	log.SetOutput(ioutil.Discard)
+	c := new(dns.Client)
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Exchange(m, udp)
+	}
+}

--- a/test/miek_test.go
+++ b/test/miek_test.go
@@ -1,0 +1,31 @@
+package test
+
+const miekNL = `; miek.nl test zone
+$TTL    30M
+$ORIGIN miek.nl.
+@       IN      SOA     linode.atoom.net. miek.miek.nl. (
+			     1282630059 ; Serial
+                             4H         ; Refresh
+                             1H         ; Retry
+                             7D         ; Expire
+                             4H )       ; Negative Cache TTL
+                IN      NS      linode.atoom.net.
+		IN	NS	ns-ext.nlnetlabs.nl.
+		IN	NS	omval.tednet.nl.
+                IN      NS      ext.ns.whyscream.net.
+
+                IN      MX      1  aspmx.l.google.com.
+                IN      MX      5  alt1.aspmx.l.google.com.
+                IN      MX      5  alt2.aspmx.l.google.com.
+                IN      MX      10 aspmx2.googlemail.com.
+                IN      MX      10 aspmx3.googlemail.com.
+
+		IN 	A       176.58.119.54
+		IN 	AAAA    2a01:7e00::f03c:91ff:fe79:234c
+                IN      HINFO "Please stop asking for ANY" "See draft-ietf-dnsop-refuse-any"
+
+a		IN 	A       176.58.119.54
+		IN 	AAAA    2a01:7e00::f03c:91ff:fe79:234c
+www     	IN 	CNAME 	a
+archive         IN      CNAME   a
+`

--- a/test/proxy_health_test.go
+++ b/test/proxy_health_test.go
@@ -1,0 +1,111 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestProxyErratic(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	corefile := `example.org:0 {
+		erratic {
+			drop 2
+		}
+	}
+`
+
+	backend, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer backend.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	// We do one lookup that should not time out.
+	// After this the backend is marked unhealthy anyway. So basically this
+	// tests that it times out.
+	p.Lookup(state, "example.org.", dns.TypeA)
+}
+
+func TestProxyThreeWay(t *testing.T) {
+	// Run 3 CoreDNS server, 2 upstream ones and a proxy. 1 Upstream is unhealthy after 1 query, but after
+	// that we should still be able to send to the other one
+	log.SetOutput(ioutil.Discard)
+
+	// Backend CoreDNS's.
+	corefileUp1 := `example.org:0 {
+		erratic {
+			drop 2
+		}
+	}
+`
+
+	up1, err := CoreDNSServer(corefileUp1)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer up1.Stop()
+
+	corefileUp2 := `example.org:0 {
+		whoami
+	}
+`
+
+	up2, err := CoreDNSServer(corefileUp2)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer up2.Stop()
+
+	addr1, _ := CoreDNSServerPorts(up1, 0)
+	if addr1 == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+	addr2, _ := CoreDNSServerPorts(up2, 0)
+	if addr2 == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+
+	// Proxying CoreDNS.
+	corefileProxy := `example.org:0 {
+		proxy . ` + addr1 + " " + addr2 + ` {
+			max_fails 1
+		}
+	}`
+
+	prx, err := CoreDNSServer(corefileProxy)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer prx.Stop()
+	addr, _ := CoreDNSServerPorts(prx, 0)
+	if addr == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+
+	for i := 0; i < 10; i++ {
+		r, err := dns.Exchange(m, addr)
+		if err != nil {
+			continue
+		}
+		// We would previously get SERVFAIL, so just getting answers here
+		// is a good sign. The actuall timeouts are handled in the err != nil case
+		// above.
+		if r.Rcode != dns.RcodeSuccess {
+			t.Fatalf("Expected success rcode, got %d", r.Rcode)
+		}
+	}
+}

--- a/test/proxy_http_health_test.go
+++ b/test/proxy_http_health_test.go
@@ -1,0 +1,90 @@
+package test
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+	"github.com/miekg/dns"
+)
+
+func TestProxyWithHTTPCheckOK(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	healthCheckServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, "OK\n")
+		}))
+	defer healthCheckServer.Close()
+
+	healthCheckURL, err := url.Parse(healthCheckServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// TODO: use URL.Port() (Go 1.8+) once we've deprecated Go 1.7 support
+	var healthCheckPort string
+	if _, healthCheckPort, err = net.SplitHostPort(healthCheckURL.Host); err != nil {
+		healthCheckPort = "80"
+	}
+
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// We have to bind to 127.0.0.1 because the server started by
+	// httptest.NewServer does, and the IP addresses of the backend
+	// DNS and HTTP servers must match.
+	authoritativeCorefile := `example.org:0 {
+	   bind 127.0.0.1
+       file ` + name + `
+}
+`
+
+	authoritativeInstance, authoritativeAddr, _, err := CoreDNSServerAndPorts(authoritativeCorefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS authoritative instance: %s", err)
+	}
+	defer authoritativeInstance.Stop()
+
+	proxyCorefile := `example.org:0 {
+    proxy . ` + authoritativeAddr + ` {
+		health_check /health:` + healthCheckPort + ` 1s
+
+	}
+}
+`
+
+	proxyInstance, proxyAddr, _, err := CoreDNSServerAndPorts(proxyCorefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS proxy instance: %s", err)
+	}
+	defer proxyInstance.Stop()
+
+	p := proxy.NewLookup([]string{proxyAddr})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect answer section with A record in it
+	if len(resp.Answer) == 0 {
+		t.Fatalf("Expected to at least one RR in the answer section, got none: %s", resp)
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -1,0 +1,129 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestLookupProxy(t *testing.T) {
+	t.Parallel()
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect answer section with A record in it
+	if len(resp.Answer) == 0 {
+		t.Fatalf("Expected to at least one RR in the answer section, got none: %s", resp)
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
+func TestLookupDnsWithForcedTcp(t *testing.T) {
+	t.Parallel()
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+
+	i, _, tcp, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookupWithOption([]string{tcp}, proxy.Options{ForceTCP: true})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect answer section with A record in it
+	if len(resp.Answer) == 0 {
+		t.Fatalf("Expected to at least one RR in the answer section, got none: %s", resp)
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
+func BenchmarkProxyLookup(b *testing.B) {
+	t := new(testing.T)
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to created zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("could not get udp listening port")
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := p.Lookup(state, "example.org.", dns.TypeA)
+		if err != nil {
+			b.Fatal("Expected to receive reply, but didn't")
+		}
+	}
+}

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -1,0 +1,103 @@
+package test
+
+import (
+	"bufio"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/coredns/coredns/core/dnsserver"
+
+	"github.com/mholt/caddy"
+)
+
+// Pasrse all README.md's of the plugin and check if every example Corefile
+// actually works. Each corefile is only used if:
+//
+// ~~~ corefile
+// . {
+//	# check-this-please
+// }
+// ~~~
+
+func TestReadme(t *testing.T) {
+	port := 30053
+	caddy.Quiet = true
+	dnsserver.Quiet = true
+
+	log.SetOutput(ioutil.Discard)
+
+	middle := filepath.Join("..", "plugin")
+	dirs, err := ioutil.ReadDir(middle)
+	if err != nil {
+		t.Fatalf("Could not read %s: %q", middle, err)
+	}
+	for _, d := range dirs {
+		if !d.IsDir() {
+			continue
+		}
+		readme := filepath.Join(middle, d.Name())
+		readme = filepath.Join(readme, "README.md")
+
+		inputs, err := corefileFromReadme(readme)
+		if err != nil {
+			continue
+		}
+
+		// Test each snippet.
+		for _, in := range inputs {
+			t.Logf("Testing %s, with %d byte snippet", readme, len(in.Body()))
+			dnsserver.Port = strconv.Itoa(port)
+			server, err := caddy.Start(in)
+			if err != nil {
+				t.Errorf("Failed to start server for input %q:\n%s", err, in.Body())
+			}
+			server.Stop()
+			port++
+		}
+	}
+}
+
+// corefileFromReadme parses a readme and returns all fragments that
+// have ~~~ corefile (or ``` corefile).
+func corefileFromReadme(readme string) ([]*Input, error) {
+	f, err := os.Open(readme)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	input := []*Input{}
+	corefile := false
+	temp := ""
+
+	for s.Scan() {
+		line := s.Text()
+		if line == "~~~ corefile" || line == "``` corefile" {
+			corefile = true
+			continue
+		}
+
+		if corefile && (line == "~~~" || line == "```") {
+			// last line
+			input = append(input, NewInput(temp))
+
+			temp = ""
+			corefile = false
+			continue
+		}
+
+		if corefile {
+			temp += line + "\n" // readd newline stripped by s.Text()
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return input, nil
+}

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestReload(t *testing.T) {
+	corefile := `.:0 {
+	whoami
+}
+`
+	coreInput := NewInput(corefile)
+
+	c, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(c, 0)
+
+	send(t, udp)
+
+	c1, err := c.Restart(coreInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	udp, _ = CoreDNSServerPorts(c1, 0)
+
+	send(t, udp)
+
+	c1.Stop()
+}
+
+func send(t *testing.T, server string) {
+	m := new(dns.Msg)
+	m.SetQuestion("whoami.example.org.", dns.TypeSRV)
+
+	r, err := dns.Exchange(m, server)
+	if err != nil {
+		// This seems to fail a lot on travis, quick'n dirty: redo
+		r, err = dns.Exchange(m, server)
+		if err != nil {
+			return
+		}
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		t.Fatalf("Expected successful reply, got %s", dns.RcodeToString[r.Rcode])
+	}
+	if len(r.Extra) != 2 {
+		t.Fatalf("Expected 2 RRs in additional, got %d", len(r.Extra))
+	}
+}

--- a/test/reverse_test.go
+++ b/test/reverse_test.go
@@ -1,0 +1,127 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestReverseFallthrough(t *testing.T) {
+	t.Parallel()
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `arpa:0 example.org:0 {
+    reverse 10.32.0.0/16 {
+        hostname ip-{ip}.{zone[2]}
+        #fallthrough
+    }
+    file ` + name + ` example.org
+}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// Reply should be SERVFAIL because of no fallthrough
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("Expected SERVFAIL, but got: %d", resp.Rcode)
+	}
+
+	// Stop the server.
+	i.Stop()
+
+	// And redo with fallthrough enabled
+
+	corefile = `arpa:0 example.org:0 {
+    reverse 10.32.0.0/16 {
+        hostname ip-{ip}.{zone[2]}
+        fallthrough
+    }
+    file ` + name + ` example.org
+}
+`
+
+	i, err = CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ = CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+	defer i.Stop()
+
+	p = proxy.NewLookup([]string{udp})
+	resp, err = p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+
+	if len(resp.Answer) == 0 {
+		t.Error("Expected to at least one RR in the answer section, got none")
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
+func TestReverseCorefile(t *testing.T) {
+	corefile := `10.0.0.0/24:0 {
+		whoami
+	}`
+
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "17.0.0.10.in-addr.arpa.", dns.TypePTR)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+
+	if len(resp.Extra) != 2 {
+		t.Fatal("Expected to at least two RRs in the extra section, got none")
+	}
+	// Second one is SRV, first one can be A or AAAA depending on system.
+	if resp.Extra[1].Header().Rrtype != dns.TypeSRV {
+		t.Errorf("Expected RR to SRV, got: %d", resp.Extra[1].Header().Rrtype)
+	}
+	if resp.Extra[1].Header().Name != "_udp.17.0.0.10.in-addr.arpa." {
+		t.Errorf("Expected _udp.17.0.0.10.in-addr.arpa. got: %s", resp.Extra[1].Header().Name)
+	}
+}

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -1,0 +1,90 @@
+package test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestRewrite(t *testing.T) {
+	t.Parallel()
+	corefile := `.:0 {
+       rewrite type MX a
+       rewrite edns0 local set 0xffee hello-world
+       erratic . {
+	drop 0
+	}
+}`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	testMX(t, udp)
+	testEdns0(t, udp)
+}
+
+func testMX(t *testing.T, server string) {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeMX)
+
+	r, err := dns.Exchange(m, server)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	// expect answer section with A record in it
+	if len(r.Answer) == 0 {
+		t.Error("Expected to at least one RR in the answer section, got none")
+	}
+	if r.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", r.Answer[0].Header().Rrtype)
+	}
+	if r.Answer[0].(*dns.A).A.String() != "192.0.2.53" {
+		t.Errorf("Expected 192.0.2.53, got: %s", r.Answer[0].(*dns.A).A.String())
+	}
+}
+
+func testEdns0(t *testing.T, server string) {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+
+	r, err := dns.Exchange(m, server)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	// expect answer section with A record in it
+	if len(r.Answer) == 0 {
+		t.Error("Expected to at least one RR in the answer section, got none")
+	}
+	if r.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", r.Answer[0].Header().Rrtype)
+	}
+	if r.Answer[0].(*dns.A).A.String() != "192.0.2.53" {
+		t.Errorf("Expected 192.0.2.53, got: %s", r.Answer[0].(*dns.A).A.String())
+	}
+	o := r.IsEdns0()
+	if o == nil || len(o.Option) == 0 {
+		t.Error("Expected EDNS0 options but got none")
+	} else {
+		if e, ok := o.Option[0].(*dns.EDNS0_LOCAL); ok {
+			if e.Code != 0xffee {
+				t.Errorf("Expected EDNS_LOCAL code 0xffee but got %x", e.Code)
+			}
+			if !bytes.Equal(e.Data, []byte("hello-world")) {
+				t.Errorf("Expected EDNS_LOCAL data 'hello-world' but got %q", e.Data)
+			}
+		} else {
+			t.Errorf("Expected EDNS0_LOCAL but got %v", o.Option[0])
+		}
+	}
+}

--- a/test/secondary_net_test.go
+++ b/test/secondary_net_test.go
@@ -1,0 +1,126 @@
+// +build net
+
+package test
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestSecondaryZoneTransfer(t *testing.T) {
+	/*
+		Test will only work when there is a CoreDNS running on part 32054
+		with example.com and willing to transfer
+		coredns -conf Corefile -dns.port 32054
+		Corefile:
+			example.com {
+			    file example.com {
+				transfer to 127.0.0.1:32053
+			    }
+			}
+		example.com:
+			example.com.		3600	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2017042730 7200 3600 1209600 3600
+
+			example.com.		65118	IN	NS	a.iana-servers.net.
+			example.com.		65118	IN	NS	b.iana-servers.net.
+			cname.example.com.       434334  IN      CNAME   a.miek.nl.
+	*/
+
+	corefile := `example.com:32053 {
+		secondary {
+			transfer from 127.0.0.1:32054
+		}
+	}
+	`
+
+	sec, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	defer sec.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("cname.example.com.", dns.TypeCNAME)
+
+	r, err := dns.Exchange(m, "127.0.0.1:32053")
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	if len(r.Answer) == 0 {
+		t.Fatalf("Expected answer section")
+	}
+
+	if r.Answer[0].(*dns.CNAME).Target != "a.miek.nl." {
+		t.Fatalf("Expected target of %s, got %s", "a.miek.nl.", r.Answer[0].(*dns.CNAME).Target)
+	}
+
+	m = new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeSOA)
+	r, err = dns.Exchange(m, "127.0.0.1:32053")
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+	if len(r.Answer) == 0 {
+		t.Fatalf("Expected answer section")
+	}
+	if r.Answer[0].(*dns.SOA).Serial != 2017042730 {
+		t.Fatalf("Expected serial of %d, got %d", 2017042730, r.Answer[0].(*dns.SOA).Serial)
+	}
+}
+
+func TestSecondaryZoneTransferUpstream(t *testing.T) {
+	/*
+		Test will only work when there is a CoreDNS running on part 32054
+		with example.com and willing to transfer
+		coredns -conf Corefile -dns.port 32054
+		Corefile:
+			example.com {
+			    file example.com {
+				transfer to 127.0.0.1:32053
+			    }
+			}
+		example.com:
+			example.com.		3600	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2017042730 7200 3600 1209600 3600
+
+			example.com.		65118	IN	NS	a.iana-servers.net.
+			example.com.		65118	IN	NS	b.iana-servers.net.
+			cname.example.com.       434334  IN      CNAME   a.miek.nl.
+	*/
+
+	corefile := `example.com:32053 {
+		secondary {
+			transfer from 127.0.0.1:32054
+			upstream 8.8.8.8
+		}
+	}
+	`
+
+	sec, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	defer sec.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("cname.example.com.", dns.TypeA)
+
+	r, err := dns.Exchange(m, "127.0.0.1:32053")
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	if len(r.Answer) != 2 {
+		t.Fatalf("Expected answer section, with 2 records, got %d", len(r.Answer))
+	}
+
+	if r.Answer[0].(*dns.CNAME).Target != "a.miek.nl." {
+		t.Fatalf("Expected target of %s, got %s", "a.miek.nl.", r.Answer[0].(*dns.CNAME).Target)
+	}
+	if r.Answer[1].Header().Name != "a.miek.nl." {
+		t.Fatalf("Expected name of %s, got %s", "a.miek.nl.", r.Answer[1].Header().Name)
+	}
+}

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestEmptySecondaryZone(t *testing.T) {
+	// Corefile that fails to transfer example.org.
+	corefile := `example.org:0 {
+		secondary {
+			transfer from 127.0.0.1:1717
+		}
+	}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "www.example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("Expected reply to be a SERVFAIL, got %d", resp.Rcode)
+	}
+}

--- a/test/server.go
+++ b/test/server.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"sync"
+
+	"github.com/coredns/coredns/core/dnsserver"
+
+	// Hook in CoreDNS.
+	_ "github.com/coredns/coredns/core"
+
+	"github.com/mholt/caddy"
+)
+
+var mu sync.Mutex
+
+// CoreDNSServer returns a CoreDNS test server. It just takes a normal Corefile as input.
+func CoreDNSServer(corefile string) (*caddy.Instance, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	caddy.Quiet = true
+	dnsserver.Quiet = true
+	log.SetOutput(ioutil.Discard)
+
+	return caddy.Start(NewInput(corefile))
+}
+
+// CoreDNSServerStop stops a server.
+func CoreDNSServerStop(i *caddy.Instance) { i.Stop() }
+
+// CoreDNSServerPorts returns the ports the instance is listening on. The integer k indicates
+// which ServerListener you want.
+func CoreDNSServerPorts(i *caddy.Instance, k int) (udp, tcp string) {
+	srvs := i.Servers()
+	if len(srvs) < k+1 {
+		return "", ""
+	}
+	u := srvs[k].LocalAddr()
+	t := srvs[k].Addr()
+
+	if u != nil {
+		udp = u.String()
+	}
+	if t != nil {
+		tcp = t.String()
+	}
+	return
+}
+
+// CoreDNSServerAndPorts combines CoreDNSServer and CoreDNSServerPorts to start a CoreDNS
+// server and returns the udp and tcp ports of the first instance.
+func CoreDNSServerAndPorts(corefile string) (i *caddy.Instance, udp, tcp string, err error) {
+	i, err = CoreDNSServer(corefile)
+	if err != nil {
+		return nil, "", "", err
+	}
+	udp, tcp = CoreDNSServerPorts(i, 0)
+	return i, udp, tcp, nil
+}
+
+// Input implements the caddy.Input interface and acts as an easy way to use a string as a Corefile.
+type Input struct {
+	corefile []byte
+}
+
+// NewInput returns a pointer to Input, containing the corefile string as input.
+func NewInput(corefile string) *Input {
+	return &Input{corefile: []byte(corefile)}
+}
+
+// Body implements the Input interface.
+func (i *Input) Body() []byte { return i.corefile }
+
+// Path implements the Input interface.
+func (i *Input) Path() string { return "Corefile" }
+
+// ServerType implements the Input interface.
+func (i *Input) ServerType() string { return "dns" }

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Start 2 tests server, server A will proxy to B, server B is an CH server.
+func TestProxyToChaosServer(t *testing.T) {
+	t.Parallel()
+	corefile := `.:0 {
+	chaos CoreDNS-001 miek@miek.nl
+}
+`
+	chaos, udpChaos, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	defer chaos.Stop()
+
+	corefileProxy := `.:0 {
+		proxy . ` + udpChaos + `
+}
+`
+	proxy, udp, _, err := CoreDNSServerAndPorts(corefileProxy)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance")
+	}
+	defer proxy.Stop()
+
+	chaosTest(t, udpChaos)
+
+	chaosTest(t, udp)
+	// chaosTest(t, tcp, "tcp"), commented out because we use the original transport to reach the
+	// proxy and we only forward to the udp port.
+}
+
+func chaosTest(t *testing.T, server string) {
+	m := new(dns.Msg)
+	m.Question = make([]dns.Question, 1)
+	m.Question[0] = dns.Question{Qclass: dns.ClassCHAOS, Name: "version.bind.", Qtype: dns.TypeTXT}
+
+	r, err := dns.Exchange(m, server)
+	if err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+	if r.Rcode != dns.RcodeSuccess || len(r.Answer) == 0 {
+		t.Fatalf("Expected successful reply, got %s", dns.RcodeToString[r.Rcode])
+	}
+	if r.Answer[0].String() != `version.bind.	0	CH	TXT	"CoreDNS-001"` {
+		t.Fatalf("Expected version.bind. reply, got %s", r.Answer[0].String())
+	}
+}

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -1,0 +1,96 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestLookupWildcard(t *testing.T) {
+	t.Parallel()
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	for _, lookup := range []string{"a.w.example.org.", "a.a.w.example.org."} {
+		resp, err := p.Lookup(state, lookup, dns.TypeTXT)
+		if err != nil || resp == nil {
+			t.Fatalf("Expected to receive reply, but didn't for %s", lookup)
+		}
+
+		// ;; ANSWER SECTION:
+		// a.w.example.org.          1800    IN      TXT     "Wildcard"
+		if resp.Rcode != dns.RcodeSuccess {
+			t.Errorf("Expected NOERROR RCODE, got %s for %s", dns.RcodeToString[resp.Rcode], lookup)
+			continue
+		}
+		if len(resp.Answer) == 0 {
+			t.Errorf("Expected to at least one RR in the answer section, got none for %s TXT", lookup)
+			t.Logf("%s", resp)
+			continue
+		}
+		if resp.Answer[0].Header().Name != lookup {
+			t.Errorf("Expected name to be %s, got: %s for TXT", lookup, resp.Answer[0].Header().Name)
+			continue
+		}
+		if resp.Answer[0].Header().Rrtype != dns.TypeTXT {
+			t.Errorf("Expected RR to be TXT, got: %d, for %s TXT", resp.Answer[0].Header().Rrtype, lookup)
+			continue
+		}
+		if resp.Answer[0].(*dns.TXT).Txt[0] != "Wildcard" {
+			t.Errorf("Expected Wildcard, got: %s, for %s TXT", resp.Answer[0].(*dns.TXT).Txt[0], lookup)
+			continue
+		}
+	}
+
+	for _, lookup := range []string{"w.example.org.", "a.w.example.org.", "a.a.w.example.org."} {
+		resp, err := p.Lookup(state, lookup, dns.TypeSRV)
+		if err != nil || resp == nil {
+			t.Fatal("Expected to receive reply, but didn't", lookup)
+		}
+
+		// ;; AUTHORITY SECTION:
+		// example.org.              1800    IN      SOA     linode.atoom.net. miek.miek.nl. 1454960557 14400 3600 604800 14400
+		if resp.Rcode != dns.RcodeSuccess {
+			t.Errorf("Expected NOERROR RCODE, got %s for %s", dns.RcodeToString[resp.Rcode], lookup)
+			continue
+		}
+		if len(resp.Answer) != 0 {
+			t.Errorf("Expected zero RRs in the answer section, got some, for %s SRV", lookup)
+			continue
+		}
+		if len(resp.Ns) == 0 {
+			t.Errorf("Expected to at least one RR in the authority section, got none, for %s SRV", lookup)
+			continue
+		}
+		if resp.Ns[0].Header().Rrtype != dns.TypeSOA {
+			t.Errorf("Expected RR to be SOA, got: %d, for %s SRV", resp.Ns[0].Header().Rrtype, lookup)
+			continue
+		}
+	}
+
+}


### PR DESCRIPTION
Integration testing for k8s based on existing k8s tests in coredns/tests  (to be removed) 
The high level flow is...

1. receive comment hook from github
2. if comment contains keyword, check locks, pull ci repo (this repo), and start test (with make)
3. pull coredns pr, make coredns
4. spin up k8s (minikube) + local docker repo
5. run integration tests
6. spin down k8s + docker repo
7. post back results

Through out the process, the PR status comment is updated using a bot account (to be created)...
1. Request received
2. Lock timeout, if failure to acquire lock
3. test in progress, with link to log
4. test completed, with summary and link to log

Still To Do
- Fix out-of-cluster api failover test - (currently skipped)
- Move etcd tagged tests from coredns/test/ to ci/test/

