### PR TITLE
Fix expected response for pods disabled

### DIFF
--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -66,9 +66,9 @@ var dnsTestCasesA = []test.Case{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
-	{ // By default, pod queries are disabled, so a pod query should return a server failure
+	{ // By default, pod queries are disabled, so a pod query should return NXDMOAIN
 		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeServerFailure,
+		Rcode: dns.RcodeNameError,
 	},
 	{ // A TXT request for dns-version should return the version of the kubernetes service discovery spec implemented
 		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,


### PR DESCRIPTION
Response for pods disabled should be `NXDOMAIN` not `SERVFAIL`, per README and per unit tests.

Fixing the expected value here first... will correct the code next.