### PR TITLE
kubernetes: Fix WaitReady

### DIFF
--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -79,7 +79,7 @@ func TestKubernetesDeployment(t *testing.T) {
 
 	t.Run("Verify_coredns_starts", func(t *testing.T) {
 		maxWait := 120
-		if kubernetes.WaitReady(maxWait) != nil {
+		if kubernetes.WaitNReady(maxWait, 2) != nil {
 			t.Fatalf("coredns failed to start in %v seconds,\nlog: %v", maxWait, kubernetes.CorednsLogs())
 		}
 	})

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -164,12 +164,18 @@ func LoadCorefileAndZonefile(corefile, zonefile string) error {
 	return WaitReady(30)
 }
 
-// WaitReady waits for coredns to be ready or times out after maxWait seconds with an error
+// WaitReady waits for 1 coredns to be ready or times out after maxWait seconds with an error
 func WaitReady(maxWait int) error {
+	return WaitNReady(maxWait, 1)
+}
+
+// WaitReady waits for n corednses to be ready or times out after maxWait seconds with an error
+func WaitNReady(maxWait, n int) error {
+
 	running := 0
 	for {
 		o, _ := Kubectl("-n kube-system get pods -l k8s-app=coredns")
-		if strings.Count(o, "Running") == 2 {
+		if strings.Count(o, "Running") == n {
 			running += 1
 		}
 		if running >= 4 {


### PR DESCRIPTION
WaitReady assumed to always wait for 2 pods, and we only launch one pod in coredns integration tests. Added WaitNReady(), and fixes to wait for only 1 pod in coredns repo integration tests, and for 2 in the deployment tests.