### PR TITLE
kubernetes: Use status instead of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ You can initiate an integration test by including "/integration" in a comment fo
 * `coredns/coredns`: Issuing an integration test from a PR in this repo will run the tests in `/coredns/ci/tests/kubernetes`.  These test a variety of coredns configurations in an attempt to provide wide integration level coverage for the `kubernetes` plugin. 
 * `coredns/deployment`: Issuing an integration test from a PR in this repo will run the tests in `/coredns/ci/tests/k8sdeployment`.  This smaller set of tests validate the kubernetes deployment script creates a functional deployment.
 
-After making the comment, the CoreDNS CI Bot should make a comment back in the originating PR that the request is received, and start the test.  The Bot will post a link to a log, and post results back to the same comment when the test is complete.  The tests typically take a few minutes to run.
+After making the comment, the CoreDNS CI Bot should post a status back in the originating PR that the request is received, and start the test.  The tests typically take a 3-5 minutes to run.
 
-The integration tests are executed one at a time, and no queue is implemented.  If a request is made while another test is in progress, it will wait for 5 minutes for the existing test to finish, or give up and post a comment to the originating PR.
+The integration tests are executed one at a time, and no queue is implemented.  If a request is made while another test is in progress, it will wait for 5 minutes for the existing test to finish, or give up and update with an error the status to the originating PR.
 
-You may request multiple integration tests for the same PR, but only one log is kept per PR.  A new integration request will overwrite the prior integration test log of the same PR.
+You may request multiple integration tests for the same PR, but only one log is kept per commit.  A new integration request will overwrite the prior integration test log of the same commit.
 
 ### Adding and Testing New Tests, or Changes to Tests
 

--- a/build/pr-comment-hook.sh
+++ b/build/pr-comment-hook.sh
@@ -32,6 +32,14 @@ fi
 # Get the PR number
 export PR=$(echo ${PAYLOAD} | jq '.issue.number' | tr -d "\n\"")
 
+# Get Repo Name
+export SOURCEPROJ=$(echo ${PAYLOAD} | jq '.repository.name' | tr -d "\n\"")
+
+# Get SHA for test head commit (used to update PR status)
+export SHA=$(curl -s --user ${GHTOKEN} -X GET https://api.github.com/repos/${COREDNSFORK}/${SOURCEPROJ}/pulls/${PR} | jq '.head.sha' | tr -d "\n\"")
+echo curl -s --user XXXXXXXX -X GET https://api.github.com/repos/${COREDNSFORK}/${SOURCEPROJ}/pulls/${PR}
+echo Commit SHA: $SHA
+
 # Create temporary workspace and set GOPATH
 workdir=$(mktemp -d)
 export GOPATH=$workdir
@@ -42,18 +50,26 @@ function rmWorkdir {
 }
 trap rmWorkdir EXIT
 
-function postStatus {
+function postComment {
     body=$1
     curl --user $GHTOKEN -X POST --data "{\"body\":\"$body\"}" https://api.github.com/repos/${COREDNSFORK}/${SOURCEPROJ}/issues/${PR}/comments | jq '.id'
 }
 
-function updateStatus {
+function updateComment {
     body=$1
     curl --user $GHTOKEN -X POST --data "{\"body\":\"$body\"}" https://api.github.com/repos/${COREDNSFORK}/${SOURCEPROJ}/issues/comments/${STATUSID}
 }
 
+function postStatus {
+    state=$1
+    descr=$2
+    url=$3
+    context="coredns/ci"
+    curl --user $GHTOKEN -X POST --data "{\"state\":\"$state\",\"description\":\"$descr\",\"target_url\":\"$url\",\"context\":\"$context\"}" https://api.github.com/repos/${COREDNSFORK}/${SOURCEPROJ}/statuses/${SHA}
+}
+
 function lockFail {
-    updateStatus "Integration test could not start. (timeout waiting for lock)"
+    postStatus "error" "Integration test could not start. (timeout waiting for lock)" "$LOG_URL"
     exit 1
 }
 
@@ -64,19 +80,19 @@ case "${body}" in
 
     [[ "${body}" =~ \/integration-cipr([0-9]+) ]] && export CIPR=${BASH_REMATCH[1]}
 
-    export SOURCEPROJ=$(echo ${PAYLOAD} | jq '.repository.name' | tr -d "\n\"")
     export DEPLOYMENTPATH=${GOPATH}/src/${COREDNSPATH}/deployment
-    export STATUSID=$(postStatus "Integration test request received.")
+    export LOG_URL="https://drone.coredns.io/log/view.html?pr=${SHA}"
+    postStatus "pending" "Integration test requested." ""
 
     # Check lock
     exec 9>/var/lock/integration-test
     flock -w 300 9 || lockFail
 
     # Setup log and post status + log link to PR
-    touch /var/www/log/${PR}.txt  2>&1
-    echo "############### Integration Test ${COREDNSREPO}:PR${PR} Workdir: ${GOPATH} #######################" > /var/www/log/${PR}.txt
-    chown www-data: /var/www/log/${PR}.txt 2>&1
-    updateStatus "Integration test started. <a href='https://drone.coredns.io/log/view.html?pr=${PR}'>View Log</a>"
+    export logpath=/var/www/log/${SHA}.txt
+    touch $logpath  2>&1
+    echo "############### Integration Test ${COREDNSREPO}:PR${PR} Workdir: ${GOPATH} #######################" > $logpath
+    chown www-data: $logpath 2>&1
 
     # Get ci code
     mkdir -p ${GOPATH}/src/${COREDNSPATH}
@@ -84,39 +100,44 @@ case "${body}" in
     git clone https://${COREDNSREPO}/ci.git
     cd ci
     if [[ -n "$CIPR" ]] ; then
-      echo "Fetching CI PR $CIPR..."
-      git fetch --depth 1 origin pull/${CIPR}/head:pr-${CIPR}
-      echo "Checkout CI PR $CIPR..."
-      git checkout pr-${CIPR}
+      echo "Fetching CI PR $CIPR..." >> $logpath 2>&1
+      git fetch --depth 1 origin pull/${CIPR}/head:pr-${CIPR} >> $logpath 2>&1
+      git checkout pr-${CIPR}  >> $logpath 2>&1
     fi
 
     # Set up a finish & clean up on exit
     function finishIntegrationTest {
-        make clean-k8s >> /var/www/log/${PR}.txt 2>&1
-        # Post result to pr
-        pass=$(cat /var/www/log/${PR}.txt | grep "^\-\-\- PASS:" | wc -l)
-        fail=$(cat /var/www/log/${PR}.txt | grep "^\-\-\- FAIL:" | wc -l)
-        subpass=$(cat /var/www/log/${PR}.txt | grep "^    \-\-\- PASS:" | wc -l)
-        subfail=$(cat /var/www/log/${PR}.txt | grep "^    \-\-\- FAIL:" | wc -l)
-        if [[ "${fail}" != "0" ]]; then
-            summary="FAIL"
+        make clean-k8s >> $logpath 2>&1
+
+        pass=$(cat $logpath | grep "^\-\-\- PASS:" | wc -l)
+        fail=$(cat $logpath | grep "^\-\-\- FAIL:" | wc -l)
+        subpass=$(cat $logpath | grep "^    \-\-\- PASS:" | wc -l)
+        subfail=$(cat $logpath | grep "^    \-\-\- FAIL:" | wc -l)
+	total=$((pass + fail))
+	totalsub=$((subpass + subfail))
+
+        summary="passed ${total} tests and ${totalsub} subtests."
+	state="success"
+        if [[ "${total}" == "0" ]]; then
+            summary="failed to complete."
+	    state="error"
         fi
-        printf -v summary '\\n\\n
-        |          | Pass   | Fail   |\\n
-        | -------- | ------ | ------ |\\n
-        | Tests    | %s     | %s     |\\n
-        | Subtests | %s     | %s     |\\n' "${pass}" "${fail}" "${subpass}" "${subfail}"
-        summary=$(echo $summary | tr -d '\n')
-        updateStatus "Integration test $status. Run time ${SECONDS} seconds. <a href='https://drone.coredns.io/log/view.html?pr=${PR}'>View Log</a>$summary"
+        if [[ "${fail}" != "0" ]]; then
+            summary="failed ${fail}/${total} tests and ${subfail}/${totalsub} subtests."
+	    state="failure"
+        fi
+
+        # Post result to pr
+        postStatus "$state" "Integration test $summary" "$LOG_URL"
         rmWorkdir
     }
     trap finishIntegrationTest EXIT
 
     # Do integration setup and test
+    postStatus "pending" "Integration test in progress." "$LOG_URL"
     export K8S_VERSION='v1.7.5'
-    status="FAIL"
     SECONDS=0
-    make test-${SOURCEPROJ} >> /var/www/log/${PR}.txt 2>&1 && status="PASS"
+    make test-${SOURCEPROJ} >> /var/www/log/${SHA}.txt 2>&1
 
   ;;
 esac


### PR DESCRIPTION
Integration test status is now posted to the via the commit status API, instead of via comments.

This presents itself as an additional check in the "Checks" section of a PR (along side travis, if travis is doing CI in the repo).  

Like this ...

![checks](https://user-images.githubusercontent.com/14335541/35303978-e2ce1ca0-0061-11e8-8e24-b72c0d83cc46.png)
