### PR TITLE
Also process PR "open" events

### DIFF
--- a/build/pr-comment-hook.sh
+++ b/build/pr-comment-hook.sh
@@ -67,7 +67,7 @@ fi
 if [[ ${event_type} == "pullrequest" ]]; then
   # Only trigger on commit synchronization
   action=$(echo ${PAYLOAD} | jq '.action' | tr -d "\n\"")
-  if [[ "${action}" != "synchronize" ]]; then
+  if [[ "${action}" != "synchronize" ]] && [[ "${action}" != "opened" ]]; then
       exit 0
   fi
 


### PR DESCRIPTION
In addition to PR "synchronize" events, also process PR "open" events.

Fixes: #33