### PR TITLE
kubernetes: Add multi kubernetes blocks test

### DIFF
--- a/test/kubernetes/multiple_k8s_test.go
+++ b/test/kubernetes/multiple_k8s_test.go
@@ -1,0 +1,69 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsTestCasesA = []test.Case{
+	{ // An A record query for an existing service should return a record
+		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.      10    IN      A       10.0.0.100"),
+		},
+	},
+	{ // An A record query for an existing service should return a record
+		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("kubernetes.default.svc.cluster.local.      20    IN      A       10.0.0.1"),
+		},
+	},
+}
+
+func TestMultiKubernetes(t *testing.T) {
+
+	corefile := `    .:53 {
+        errors
+        log
+        kubernetes cluster.local {
+            namespaces test-1
+            ttl 10
+            fallthrough
+        }
+        kubernetes cluster.local {
+            namespaces default
+            ttl 20
+        }
+    }
+`
+
+	err := LoadCorefile(corefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+	testCases := dnsTestCasesA
+	namespace := "test-1"
+	err = StartClientPod(namespace)
+	if err != nil {
+		t.Fatalf("failed to start client pod: %s", err)
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
+			res, err := DoIntegrationTest(tc, namespace)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			test.CNAMEOrder(t, res)
+			test.SortAndCheck(t, res, tc)
+			if t.Failed() {
+				t.Errorf("coredns log: %s", CorednsLogs())
+			}
+		})
+	}
+}

--- a/test/kubernetes/multiple_k8s_test.go
+++ b/test/kubernetes/multiple_k8s_test.go
@@ -62,7 +62,7 @@ func TestMultiKubernetes(t *testing.T) {
 
 		res, _, err := c.Exchange(m, udp)
 		if err != nil {
-			t.Fatalf("Could not send query: %s", err)
+			t.Errorf("Could not send query: %s", err)
 		}
 		test.SortAndCheck(t, res, tc)
 	}

--- a/test/kubernetes/multiple_k8s_test.go
+++ b/test/kubernetes/multiple_k8s_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-var dnsTestCasesA = []test.Case{
+var multiK8sCases = []test.Case{
 	{ // An A record query for an existing service should return a record
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
@@ -47,7 +47,7 @@ func TestMultiKubernetes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not load corefile: %s", err)
 	}
-	testCases := dnsTestCasesA
+	testCases := multiK8sCases
 	namespace := "test-1"
 	err = StartClientPod(namespace)
 	if err != nil {


### PR DESCRIPTION
Add simple test for multi kubernetes blocks.

Queries in default namespace should fall through to the second kubernetes block. Use TTL to identify the answering block. 

```
    .:53 {
        errors
        log
        kubernetes cluster.local {
            namespaces test-1
            ttl 10
            fallthrough
        }
        kubernetes cluster.local {
            namespaces default
            ttl 20
        }
    }
```