### PR TITLE
kubernetes: upstream loop limit check

### DIFF
--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -206,4 +206,17 @@ spec:
   - name: c-port
     port: 1234
     protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: upriver
+  namespace: test-2
+spec:
+  type: ExternalName
+  externalName: up.river.local
+  ports:
+  - name: c-port
+    port: 1234
+    protocol: UDP
 

--- a/test/kubernetes/upstream_test.go
+++ b/test/kubernetes/upstream_test.go
@@ -101,8 +101,8 @@ func TestUpstreamLoopBreak(t *testing.T) {
 			Qname: "upriver.test-2.svc.cluster.local.", Qtype: dns.TypeA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.CNAME("upriver.test-2.svc.cluster.local.  303  IN  CNAME  up.river.local."),
 				test.CNAME("up.river.local                     303  IN  CNAME  upriver.test-2.svc.cluster.local."),
+				test.CNAME("upriver.test-2.svc.cluster.local.  303  IN  CNAME  up.river.local."),
 			},
 		},
 	}
@@ -134,7 +134,6 @@ func TestUpstreamLoopBreak(t *testing.T) {
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			test.CNAMEOrder(t, res)
 			test.SortAndCheck(t, res, tc)
 			if t.Failed() {
 				t.Errorf("coredns log: %s", CorednsLogs())

--- a/test/kubernetes/upstream_test.go
+++ b/test/kubernetes/upstream_test.go
@@ -101,8 +101,8 @@ func TestUpstreamLoopBreak(t *testing.T) {
 			Qname: "upriver.test-2.svc.cluster.local.", Qtype: dns.TypeA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.CNAME("up.river.local                     303  IN  CNAME  upriver.test-2.svc.cluster.local."),
 				test.CNAME("upriver.test-2.svc.cluster.local.  303  IN  CNAME  up.river.local."),
+				test.CNAME("up.river.local                     303  IN  CNAME  upriver.test-2.svc.cluster.local."),
 			},
 		},
 	}


### PR DESCRIPTION
Create a CNAME chain loop, and make sure a query to it doesn't recurse forever.