### PR TITLE
Fix failures due to k8s-app label change

### DIFF
--- a/build/kubernetes/coredns.yaml
+++ b/build/kubernetes/coredns.yaml
@@ -59,18 +59,18 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    k8s-app: coredns
+    k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: coredns
+      k8s-app: kube-dns
   template:
     metadata:
       labels:
-        k8s-app: coredns
+        k8s-app: kube-dns
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -107,12 +107,12 @@ metadata:
   name: kube-dns
   namespace: kube-system
   labels:
-    k8s-app: coredns
+    k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
 spec:
   selector:
-    k8s-app: coredns
+    k8s-app: kube-dns
   clusterIP: 10.0.0.10
   ports:
   - name: dns

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -159,7 +159,7 @@ func LoadCorefileAndZonefile(corefile, zonefile string) error {
 	}
 
 	// force coredns pod reload the config
-	Kubectl("-n kube-system delete pods -l k8s-app=coredns")
+	Kubectl("-n kube-system delete pods -l k8s-app=kube-dns")
 
 	return WaitReady(30)
 }
@@ -174,7 +174,7 @@ func WaitNReady(maxWait, n int) error {
 
 	running := 0
 	for {
-		o, _ := Kubectl("-n kube-system get pods -l k8s-app=coredns")
+		o, _ := Kubectl("-n kube-system get pods -l k8s-app=kube-dns")
 		if strings.Count(o, "Running") == n {
 			running += 1
 		}
@@ -195,7 +195,7 @@ func WaitNReady(maxWait, n int) error {
 
 // CorednsLogs returns the current coredns log
 func CorednsLogs() string {
-	name, _ := Kubectl("-n kube-system get pods -l k8s-app=coredns | grep Running | cut -f1 -d' ' | tr -d '\n'")
+	name, _ := Kubectl("-n kube-system get pods -l k8s-app=kube-dns | grep Running | cut -f1 -d' ' | tr -d '\n'")
 	logs, _ := Kubectl("-n kube-system logs " + name)
 	return (logs)
 }
@@ -215,7 +215,7 @@ func prepForConfigMap(config string) string {
 
 // CoreDNSPodIPs return the ips of all coredns pods
 func CoreDNSPodIPs() ([]string, error) {
-	lines, err := Kubectl("-n kube-system get pods -l k8s-app=coredns -o wide | awk '{print $6}' | tail -n+2")
+	lines, err := Kubectl("-n kube-system get pods -l k8s-app=kube-dns -o wide | awk '{print $6}' | tail -n+2")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change label to kube-dns to prevent break in CI test after change in coredns manifest in https://github.com/coredns/deployment/pull/69