### PR TITLE
Update minikube + k8s

### DIFF
--- a/build/kubernetes/coredns.yaml
+++ b/build/kubernetes/coredns.yaml
@@ -48,7 +48,7 @@ data:
   Corefile: |
     .:53 {
         errors
-        kubernetes cluster.local 10.0.0.0/8
+        kubernetes cluster.local 10.96.0.0/8
     }
   Zonefile: |
 
@@ -113,7 +113,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: 10.0.0.10
+  clusterIP: 10.96.0.10
   ports:
   - name: dns
     port: 53

--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -74,7 +74,7 @@ metadata:
   name: svc-1-a
   namespace: test-1
 spec:
-  clusterIP: 10.0.0.100
+  clusterIP: 10.96.0.100
   ports:
   - name: http
     port: 80
@@ -107,7 +107,7 @@ metadata:
 spec:
   selector:
     app: app-1-b
-  clusterIP: 10.0.0.110
+  clusterIP: 10.96.0.110
   ports:
   - name: http
     port: 80
@@ -121,7 +121,7 @@ metadata:
 spec:
   selector:
     app: app-c
-  clusterIP: 10.0.0.115
+  clusterIP: 10.96.0.115
   ports:
   - name: c-port
     port: 1234
@@ -135,7 +135,7 @@ metadata:
 spec:
   selector:
     app: app-c
-  clusterIP: 10.0.0.120
+  clusterIP: 10.96.0.120
   ports:
   - name: c-port
     port: 1234
@@ -147,7 +147,7 @@ metadata:
   name: svc-d
   namespace: test-2
 spec:
-  clusterIP: 10.0.0.121
+  clusterIP: 10.96.0.121
   ports:
   - name: c-port
     port: 1234

--- a/build/kubernetes/minikube_install.sh
+++ b/build/kubernetes/minikube_install.sh
@@ -3,7 +3,7 @@ set -v
 
 # Install minikube and kubectl
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube
-curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl && chmod +x kubectl
+curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x kubectl
 mv ./minikube /usr/local/bin/
 mv ./kubectl /usr/local/bin/
 

--- a/build/kubernetes/minikube_install.sh
+++ b/build/kubernetes/minikube_install.sh
@@ -2,7 +2,7 @@
 set -v
 
 # Install minikube and kubectl
-curl -Lo minikube https://github.com/kubernetes/minikube/releases/tag/v0.27.0 && chmod +x minikube
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.27.0/minikube-linux-amd64 && chmod +x minikube
 curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x kubectl
 mv ./minikube /usr/local/bin/
 mv ./kubectl /usr/local/bin/

--- a/build/kubernetes/minikube_install.sh
+++ b/build/kubernetes/minikube_install.sh
@@ -2,7 +2,7 @@
 set -v
 
 # Install minikube and kubectl
-curl -Lo minikube https://github.com/kubernetes/minikube/releases/tag/latest && chmod +x minikube
+curl -Lo minikube https://github.com/kubernetes/minikube/releases/tag/v0.27.0 && chmod +x minikube
 curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x kubectl
 mv ./minikube /usr/local/bin/
 mv ./kubectl /usr/local/bin/

--- a/build/kubernetes/minikube_install.sh
+++ b/build/kubernetes/minikube_install.sh
@@ -2,7 +2,7 @@
 set -v
 
 # Install minikube and kubectl
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube
+curl -Lo minikube https://github.com/kubernetes/minikube/releases/tag/latest && chmod +x minikube
 curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x kubectl
 mv ./minikube /usr/local/bin/
 mv ./kubectl /usr/local/bin/

--- a/build/kubernetes/minikube_setup.sh
+++ b/build/kubernetes/minikube_setup.sh
@@ -16,7 +16,7 @@ touch $HOME/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
 
-minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
+minikube start --vm-driver=none --kubernetes-version=v1.10.0
 
 # Wait for minkube's api service to be ready
 for i in {1..60} # timeout for 2 minutes

--- a/build/kubernetes/minikube_setup.sh
+++ b/build/kubernetes/minikube_setup.sh
@@ -30,6 +30,7 @@ done
 
 # Disable kube-dns in addon manager
 minikube addons disable kube-dns 2> /dev/null
+kubectl delete deployment kube-dns -n kube-system
 
 # Deploy test objects
 kubectl create -f ${ci_bin}/kubernetes/dns-test.yaml

--- a/build/kubernetes/minikube_teardown.sh
+++ b/build/kubernetes/minikube_teardown.sh
@@ -7,6 +7,7 @@ kill -9 `cat /var/run/kubectl_proxy.pid`
 
 # delete minikube instance
 minikube delete
+kubeadm reset
 
 # Delete the docker image repository
 docker stop registry

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -85,40 +85,42 @@ func TestKubernetesDeployment(t *testing.T) {
 		}
 	})
 
-	t.Run("Verify_coredns_healthy", func(t *testing.T) {
-		timeout := time.Second * time.Duration(90)
+	if false {
+		t.Run("Verify_coredns_healthy", func(t *testing.T) {
+			timeout := time.Second * time.Duration(90)
 
-		ips, err := kubernetes.CoreDNSPodIPs()
-		if err != nil {
-			t.Errorf("could not get coredns pod ips: %v", err)
-		}
-		if len(ips) != 2 {
-			t.Errorf("Expected 2 pods, found: %v", len(ips))
-		}
-		for _, ip := range ips {
-			start := time.Now()
-			for {
-				resp, err := http.Get("http://" + ip + ":8080/health")
-				if err != nil {
-					t.Logf("pod (%v) healthy check error %v", ip, err)
-					time.Sleep(time.Second)
-					continue
-				}
-
-				// Any code greater than or equal to 200 and less than 400 indicates success.
-				// Any other code indicates failure.
-				if resp.StatusCode >= 200 && resp.StatusCode < 400 {
-					break
-				}
-
-				if time.Since(start) >= timeout {
-					t.Errorf("pod (%v) was not healthy in %v", ip, timeout)
-					break
-				}
-				time.Sleep(time.Second)
+			ips, err := kubernetes.CoreDNSPodIPs()
+			if err != nil {
+				t.Errorf("could not get coredns pod ips: %v", err)
 			}
-		}
-	})
+			if len(ips) != 2 {
+				t.Errorf("Expected 2 pods, found: %v", len(ips))
+			}
+			for _, ip := range ips {
+				start := time.Now()
+				for {
+					resp, err := http.Get("http://" + ip + ":8080/health")
+					if err != nil {
+						t.Logf("pod (%v) healthy check error %v", ip, err)
+						time.Sleep(time.Second)
+						continue
+					}
+
+					// Any code greater than or equal to 200 and less than 400 indicates success.
+					// Any other code indicates failure.
+					if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+						break
+					}
+
+					if time.Since(start) >= timeout {
+						t.Errorf("pod (%v) was not healthy in %v", ip, timeout)
+						break
+					}
+					time.Sleep(time.Second)
+				}
+			}
+		})
+	}
 
 	t.Run("Verify_metrics_available", func(t *testing.T) {
 		ips, err := kubernetes.CoreDNSPodIPs()

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -72,69 +72,71 @@ func TestKubernetesDeployment(t *testing.T) {
 		cmd := exec.Command("sh", "-c", "./deploy.sh -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
+		print(string(cmdout))
 		if err != nil {
 			t.Fatalf("deployment script failed: %s\nerr: %s", string(cmdout), err)
 		}
 	})
 
-	t.Run("Verify_coredns_starts", func(t *testing.T) {
-		maxWait := 120
-		if kubernetes.WaitNReady(maxWait, 2) != nil {
-			t.Fatalf("coredns failed to start in %v seconds,\nlog: %v", maxWait, kubernetes.CorednsLogs())
-		}
-	})
+	if false {
+		t.Run("Verify_coredns_starts", func(t *testing.T) {
+			maxWait := 120
+			if kubernetes.WaitNReady(maxWait, 2) != nil {
+				t.Fatalf("coredns failed to start in %v seconds,\nlog: %v", maxWait, kubernetes.CorednsLogs())
+			}
+		})
 
-	t.Run("Verify_coredns_healthy", func(t *testing.T) {
-		timeout := time.Second * time.Duration(90)
+		t.Run("Verify_coredns_healthy", func(t *testing.T) {
+			timeout := time.Second * time.Duration(90)
 
-		ips, err := kubernetes.CoreDNSPodIPs()
-		if err != nil {
-			t.Errorf("could not get coredns pod ips: %v", err)
-		}
-		if len(ips) != 2 {
-			t.Errorf("Expected 2 pods, found: %v", len(ips))
-		}
-		for _, ip := range ips {
-			start := time.Now()
-			for {
-				resp, err := http.Get("http://" + ip + ":8080/health")
-				if err != nil {
-					t.Logf("pod (%v) healthy check error %v", ip, err)
+			ips, err := kubernetes.CoreDNSPodIPs()
+			if err != nil {
+				t.Errorf("could not get coredns pod ips: %v", err)
+			}
+			if len(ips) != 2 {
+				t.Errorf("Expected 2 pods, found: %v", len(ips))
+			}
+			for _, ip := range ips {
+				start := time.Now()
+				for {
+					resp, err := http.Get("http://" + ip + ":8080/health")
+					if err != nil {
+						t.Logf("pod (%v) healthy check error %v", ip, err)
+						time.Sleep(time.Second)
+						continue
+					}
+
+					// Any code greater than or equal to 200 and less than 400 indicates success.
+					// Any other code indicates failure.
+					if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+						break
+					}
+
+					if time.Since(start) >= timeout {
+						t.Errorf("pod (%v) was not healthy in %v", ip, timeout)
+						break
+					}
 					time.Sleep(time.Second)
-					continue
 				}
-
-				// Any code greater than or equal to 200 and less than 400 indicates success.
-				// Any other code indicates failure.
-				if resp.StatusCode >= 200 && resp.StatusCode < 400 {
-					break
-				}
-
-				if time.Since(start) >= timeout {
-					t.Errorf("pod (%v) was not healthy in %v", ip, timeout)
-					break
-				}
-				time.Sleep(time.Second)
 			}
-		}
-	})
+		})
 
-	t.Run("Verify_metrics_available", func(t *testing.T) {
-		ips, err := kubernetes.CoreDNSPodIPs()
-		if err != nil {
-			t.Errorf("could not get coredns pod ips: %v", err)
-		}
-		if len(ips) != 2 {
-			t.Errorf("Expected 2 pods, found: %v", len(ips))
-		}
-		for _, ip := range ips {
-			mf := metrics.Scrape(t, "http://"+ip+":9153/metrics")
-			if len(mf) == 0 {
-				t.Errorf("unable to scrape metrics from %v", ip)
+		t.Run("Verify_metrics_available", func(t *testing.T) {
+			ips, err := kubernetes.CoreDNSPodIPs()
+			if err != nil {
+				t.Errorf("could not get coredns pod ips: %v", err)
 			}
-		}
-	})
-
+			if len(ips) != 2 {
+				t.Errorf("Expected 2 pods, found: %v", len(ips))
+			}
+			for _, ip := range ips {
+				mf := metrics.Scrape(t, "http://"+ip+":9153/metrics")
+				if len(mf) == 0 {
+					t.Errorf("unable to scrape metrics from %v", ip)
+				}
+			}
+		})
+	}
 	// Verify dns query test strict cases
 	testCases := deploymentDNSCases
 	namespace := "test-1"

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -69,7 +69,7 @@ func TestKubernetesDeployment(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
 		path := os.Getenv("DEPLOYMENTPATH")
-		cmd := exec.Command("sh", "-c", "./deploy.sh -i 10.0.0.10 -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+		cmd := exec.Command("sh", "-c", "./deploy.sh  -i 10.0.0.10 -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
 		print(string(cmdout))

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -69,7 +69,7 @@ func TestKubernetesDeployment(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
 		path := os.Getenv("DEPLOYMENTPATH")
-		cmd := exec.Command("sh", "-c", "./deploy.sh -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+		cmd := exec.Command("sh", "-c", "./deploy.sh -i 10.0.0.10 -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
 		print(string(cmdout))

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -69,7 +69,7 @@ func TestKubernetesDeployment(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
 		path := os.Getenv("DEPLOYMENTPATH")
-		cmd := exec.Command("sh", "-c", "./deploy.sh -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f --validate=false -")
+		cmd := exec.Command("sh", "-c", "./deploy.sh -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
 		print(string(cmdout))

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -72,7 +72,6 @@ func TestKubernetesDeployment(t *testing.T) {
 		cmd := exec.Command("sh", "-c", "./deploy.sh  -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
-		print(string(cmdout))
 		if err != nil {
 			t.Fatalf("deployment script failed: %s\nerr: %s", string(cmdout), err)
 		}
@@ -85,42 +84,40 @@ func TestKubernetesDeployment(t *testing.T) {
 		}
 	})
 
-	if false {
-		t.Run("Verify_coredns_healthy", func(t *testing.T) {
-			timeout := time.Second * time.Duration(90)
+	t.Run("Verify_coredns_healthy", func(t *testing.T) {
+		timeout := time.Second * time.Duration(90)
 
-			ips, err := kubernetes.CoreDNSPodIPs()
-			if err != nil {
-				t.Errorf("could not get coredns pod ips: %v", err)
-			}
-			if len(ips) != 2 {
-				t.Errorf("Expected 2 pods, found: %v", len(ips))
-			}
-			for _, ip := range ips {
-				start := time.Now()
-				for {
-					resp, err := http.Get("http://" + ip + ":8080/health")
-					if err != nil {
-						t.Logf("pod (%v) healthy check error %v", ip, err)
-						time.Sleep(time.Second)
-						continue
-					}
-
-					// Any code greater than or equal to 200 and less than 400 indicates success.
-					// Any other code indicates failure.
-					if resp.StatusCode >= 200 && resp.StatusCode < 400 {
-						break
-					}
-
-					if time.Since(start) >= timeout {
-						t.Errorf("pod (%v) was not healthy in %v", ip, timeout)
-						break
-					}
+		ips, err := kubernetes.CoreDNSPodIPs()
+		if err != nil {
+			t.Errorf("could not get coredns pod ips: %v", err)
+		}
+		if len(ips) != 2 {
+			t.Errorf("Expected 2 pods, found: %v", len(ips))
+		}
+		for _, ip := range ips {
+			start := time.Now()
+			for {
+				resp, err := http.Get("http://" + ip + ":8080/health")
+				if err != nil {
+					t.Logf("pod (%v) healthy check error %v", ip, err)
 					time.Sleep(time.Second)
+					continue
 				}
+
+				// Any code greater than or equal to 200 and less than 400 indicates success.
+				// Any other code indicates failure.
+				if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+					break
+				}
+
+				if time.Since(start) >= timeout {
+					t.Errorf("pod (%v) was not healthy in %v", ip, timeout)
+					break
+				}
+				time.Sleep(time.Second)
 			}
-		})
-	}
+		}
+	})
 
 	t.Run("Verify_metrics_available", func(t *testing.T) {
 		ips, err := kubernetes.CoreDNSPodIPs()

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -69,7 +69,7 @@ func TestKubernetesDeployment(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
 		path := os.Getenv("DEPLOYMENTPATH")
-		cmd := exec.Command("sh", "-c", "./deploy.sh -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+		cmd := exec.Command("sh", "-c", "./deploy.sh -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f --validate=false -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
 		print(string(cmdout))

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -30,10 +30,10 @@ var deploymentDNSCases = []test.Case{
 		},
 	},
 	{ // A PTR record query for an existing service should return a record
-		Qname: "100.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Qname: "100.0.96.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.PTR("100.0.0.10.in-addr.arpa. 303	IN	PTR	svc-1-a.test-1.svc.cluster.local."),
+			test.PTR("100.0.96.10.in-addr.arpa. 303	IN	PTR	svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
 	{ // A PTR record query for an existing endpoint should return a record

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -19,7 +19,7 @@ var deploymentDNSCases = []test.Case{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      5    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      5    IN      A       10.96.0.100"),
 		},
 	},
 	{ // A query for an ip-style pod dns name should return a record
@@ -69,7 +69,7 @@ func TestKubernetesDeployment(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
 		path := os.Getenv("DEPLOYMENTPATH")
-		cmd := exec.Command("sh", "-c", "./deploy.sh  -i 10.0.0.10 -r 10.0.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+		cmd := exec.Command("sh", "-c", "./deploy.sh  -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
 		print(string(cmdout))

--- a/test/kubernetai/address_test.go
+++ b/test/kubernetai/address_test.go
@@ -33,17 +33,17 @@ var dnsTestCases = []test.Case{
 		},
 	},
 	{ // A PTR record in first stanza
-		Qname: "100.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Qname: "100.0.96.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.PTR("100.0.0.10.in-addr.arpa. 10	IN	PTR	svc-1-a.test-1.svc.cluster.local."),
+			test.PTR("100.0.96.10.in-addr.arpa. 10	IN	PTR	svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
 	{ // A PTR record in second stanza via fallthrough
-		Qname: "1.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Qname: "1.0.96.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.PTR("1.0.0.10.in-addr.arpa. 20	IN	PTR	kubernetes.default.svc.cluster.local."),
+			test.PTR("1.0.96.10.in-addr.arpa. 20	IN	PTR	kubernetes.default.svc.cluster.local."),
 		},
 	},
 }

--- a/test/kubernetai/address_test.go
+++ b/test/kubernetai/address_test.go
@@ -15,21 +15,21 @@ var dnsTestCases = []test.Case{
 		Qname: "svc-1-a.test-1.svc.conglomeration.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.conglomeration.local.      30    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.conglomeration.local.      30    IN      A       10.96.0.100"),
 		},
 	},
 	{ // Query service served by first stanza
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      10    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      10    IN      A       10.96.0.100"),
 		},
 	},
 	{ // Query service served by second stanza via fallthrough
 		Qname: "kubernetes.default.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("kubernetes.default.svc.cluster.local.      20    IN      A       10.0.0.1"),
+			test.A("kubernetes.default.svc.cluster.local.      20    IN      A       10.96.0.1"),
 		},
 	},
 	{ // A PTR record in first stanza

--- a/test/kubernetai/autopath_test.go
+++ b/test/kubernetai/autopath_test.go
@@ -15,14 +15,14 @@ var autopathTests = []test.Case{
 		Qname: "svc-1-a", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 		},
 	},
 	{ // Valid service name + namespace -> success on 2nd search in path -> CNAME glue + A record
 		Qname: "svc-1-a.test-1", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 			test.CNAME("svc-1-a.test-1.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
@@ -30,7 +30,7 @@ var autopathTests = []test.Case{
 		Qname: "svc-1-a.test-1.svc", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 			test.CNAME("svc-1-a.test-1.svc.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
@@ -38,7 +38,7 @@ var autopathTests = []test.Case{
 		Qname: "svc-1-a.test-1.svc.cluster.local", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 			test.CNAME("svc-1-a.test-1.svc.cluster.local.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
 		},
 	},

--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -14,7 +14,7 @@ var dnsTestCasesA = []test.Case{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      5    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      5    IN      A       10.96.0.100"),
 		},
 	},
 	{ // An A record query for an existing headless service should return a record for each of its ipv4 endpoints
@@ -43,16 +43,16 @@ var dnsTestCasesA = []test.Case{
 		Qname: "svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.*.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.*.svc.cluster.local.      303    IN      A       10.96.0.100"),
 		},
 	},
 	{ // A wild card service name in an exposed namespace should result in all records
 		Qname: "*.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
-			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.110"),
-			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.115"),
+			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
+			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.96.0.110"),
+			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.96.0.115"),
 			test.A("*.test-1.svc.cluster.local.      303    IN      A       172.17.0.254"),
 			test.A("*.test-1.svc.cluster.local.      303    IN      A       172.17.0.255"),
 			test.CNAME("*.test-1.svc.cluster.local.  303    IN      CNAME   example.net."),

--- a/test/kubernetes/autopath_test.go
+++ b/test/kubernetes/autopath_test.go
@@ -14,14 +14,14 @@ var autopathTests = []test.Case{
 		Qname: "svc-1-a", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 		},
 	},
 	{ // Valid service name + namespace -> success on 2nd search in path -> CNAME glue + A record
 		Qname: "svc-1-a.test-1", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 			test.CNAME("svc-1-a.test-1.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
@@ -29,7 +29,7 @@ var autopathTests = []test.Case{
 		Qname: "svc-1-a.test-1.svc", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 			test.CNAME("svc-1-a.test-1.svc.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
@@ -37,7 +37,7 @@ var autopathTests = []test.Case{
 		Qname: "svc-1-a.test-1.svc.cluster.local", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 			test.CNAME("svc-1-a.test-1.svc.cluster.local.test-1.svc.cluster.local.  303    IN	     CNAME	  svc-1-a.test-1.svc.cluster.local."),
 		},
 	},

--- a/test/kubernetes/excluster_test.go
+++ b/test/kubernetes/excluster_test.go
@@ -15,7 +15,7 @@ var tests = []test.Case{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 		},
 	},
 }

--- a/test/kubernetes/nsexposure_test.go
+++ b/test/kubernetes/nsexposure_test.go
@@ -14,14 +14,14 @@ var dnsTestCasesAllNSExposed = []test.Case{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 		},
 	},
 	{
 		Qname: "svc-c.test-2.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc-c.test-2.svc.cluster.local.      303    IN      A       10.0.0.120"),
+			test.A("svc-c.test-2.svc.cluster.local.      303    IN      A       10.96.0.120"),
 		},
 	},
 }

--- a/test/kubernetes/ptr_test.go
+++ b/test/kubernetes/ptr_test.go
@@ -11,10 +11,10 @@ import (
 
 var dnsTestCasesPTR = []test.Case{
 	{ // A PTR record query for an existing service should return a record
-		Qname: "100.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Qname: "100.0.96.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.PTR("100.0.0.10.in-addr.arpa. 303	IN	PTR	svc-1-a.test-1.svc.cluster.local."),
+			test.PTR("100.0.96.10.in-addr.arpa. 303	IN	PTR	svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
 	{ // A PTR record query for an existing endpoint should return a record
@@ -32,10 +32,10 @@ var dnsTestCasesPTR = []test.Case{
 		},
 	},
 	{ // A PTR record query for an existing service in an UNEXPOSED namespace should return NXDOMAIN
-		Qname: "120.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Qname: "120.0.96.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
-			test.SOA("0.0.10.in-addr.arpa.	303	IN	SOA	ns.dns.0.0.10.in-addr.arpa. hostmaster.0.0.10.in-addr.arpa. 1510339777 7200 1800 86400 30"),
+			test.SOA("0.96.10.in-addr.arpa.	303	IN	SOA	ns.dns.0.96.10.in-addr.arpa. hostmaster.0.96.10.in-addr.arpa. 1510339777 7200 1800 86400 30"),
 		},
 	},
 	{ // A PTR record query for an existing endpoint in an UNEXPOSED namespace should return NXDOMAIN

--- a/test/kubernetes/ptr_test.go
+++ b/test/kubernetes/ptr_test.go
@@ -58,7 +58,7 @@ func TestKubernetesPTR(t *testing.T) {
 	corefile := `    .:53 {
         errors
         log
-        kubernetes cluster.local 10.0.0.0/24 172.17.0.0/24 1234:abcd::0/64 {
+        kubernetes cluster.local 10.96.0.0/24 172.17.0.0/24 1234:abcd::0/64 {
             namespaces test-1
         }
     }

--- a/test/kubernetes/srv_test.go
+++ b/test/kubernetes/srv_test.go
@@ -24,7 +24,7 @@ var dnsTestCasesSRV = []test.Case{
 			test.SRV("*._TcP.svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	 0  50   80 svc-1-a.test-1.svc.cluster.local."),
 		},
 		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303 	IN	A	10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.	303 	IN	A	10.96.0.100"),
 		},
 	},
 	{
@@ -42,7 +42,7 @@ var dnsTestCasesSRV = []test.Case{
 			test.SRV("*.any.svc-1-a.*.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-a.test-1.svc.cluster.local."),
 		},
 		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.96.0.100"),
 		},
 	},
 	{
@@ -53,7 +53,7 @@ var dnsTestCasesSRV = []test.Case{
 			test.SRV("ANY.*.svc-1-a.any.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-a.test-1.svc.cluster.local."),
 		},
 		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303 	IN	A	10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.	303 	IN	A	10.96.0.100"),
 		},
 	},
 	{
@@ -85,7 +85,7 @@ var dnsTestCasesSRV = []test.Case{
 			test.AAAA("1234-abcd--2.headless-svc.test-1.svc.cluster.local.     303       IN      AAAA    1234:abcd::2"),
 			test.A("172-17-0-254.headless-svc.test-1.svc.cluster.local.	303	IN	A	172.17.0.254"),
 			test.A("172-17-0-255.headless-svc.test-1.svc.cluster.local.	303	IN	A	172.17.0.255"),
-			test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.0.0.115"),
+			test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.96.0.115"),
 		},
 	},
 	{
@@ -97,8 +97,8 @@ var dnsTestCasesSRV = []test.Case{
 			test.SRV("*._tcp.any.test-1.svc.cluster.local.      303    IN    SRV 0 33 80  svc-1-b.test-1.svc.cluster.local."),
 		},
 		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.0.0.110"),
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.96.0.100"),
+			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.96.0.110"),
 		},
 	},
 	{
@@ -123,8 +123,8 @@ var dnsTestCasesSRV = []test.Case{
 			test.SRV("_http._tcp.*.*.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-b.test-1.svc.cluster.local."),
 		},
 		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.0.0.110"),
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.96.0.100"),
+			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.96.0.110"),
 		},
 	},
 	{
@@ -153,7 +153,7 @@ var dnsTestCasesSRV = []test.Case{
 			test.SRV("svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	0 50 80 svc-1-a.test-1.svc.cluster.local."),
 		},
 		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
+			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.96.0.100"),
 		},
 	},
 }

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -34,7 +34,6 @@ func DoIntegrationTest(tc test.Case, namespace string) (*dns.Msg, error) {
 	for {
 		cmdout, err = Kubectl("-n " + namespace + " exec " + clientName + " -- " + digCmd)
 		if err == nil {
-			println("dig query: " + cmdout)
 			break
 		}
 		tries = tries - 1

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -42,7 +42,9 @@ func DoIntegrationTest(tc test.Case, namespace string) (*dns.Msg, error) {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	println("DEBUG: "+cmdout)
 	results, err := ParseDigResponse(cmdout)
+
 	if err != nil {
 		return nil, errors.New("failed to parse result: (" + err.Error() + ")" + cmdout)
 	}

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -42,7 +42,6 @@ func DoIntegrationTest(tc test.Case, namespace string) (*dns.Msg, error) {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	println("DEBUG: "+cmdout)
 	results, err := ParseDigResponse(cmdout)
 
 	if err != nil {

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -34,6 +34,7 @@ func DoIntegrationTest(tc test.Case, namespace string) (*dns.Msg, error) {
 	for {
 		cmdout, err = Kubectl("-n " + namespace + " exec " + clientName + " -- " + digCmd)
 		if err == nil {
+			println("dig query: " + cmdout)
 			break
 		}
 		tries = tries - 1
@@ -255,6 +256,9 @@ func ParseDigResponse(r string) ([]*dns.Msg, error) {
 		m, err := parseDig(s)
 		if err != nil {
 			break
+		}
+		if m == nil {
+			return nil, errors.New("Unexpected nil message")
 		}
 		msgs = append(msgs, m)
 	}

--- a/test/kubernetes/tools_test.go
+++ b/test/kubernetes/tools_test.go
@@ -40,15 +40,15 @@ cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 150231
 
 ;; ANSWER SECTION:
 cname.test-1.svc.cluster.local.		5	IN	CNAME	svc-1-a.test-1.svc.cluster.local.
-svc-1-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.100
-svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.101
+svc-1-a.test-1.svc.cluster.local.		5	IN	A	10.96.0.100
+svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.96.0.101
 
 ;; AUTHORITY SECTION:
 cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60
 
 ;; ADDITIONAL SECTION:
-svc-1-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.100
-svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.101
+svc-1-a.test-1.svc.cluster.local.		5	IN	A	10.96.0.100
+svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.96.0.101
 
 ;; Query time: 4 msec
 ;; SERVER: 64.207.129.21#53(64.207.129.21)
@@ -68,15 +68,15 @@ svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.101
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
 				test.CNAME("cname.test-1.svc.cluster.local.      303    IN      CNAME       svc-1-a.test-1.svc.cluster.local."),
-				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
-				test.A("svc-2-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.101"),
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
+				test.A("svc-2-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.101"),
 			},
 			Ns: []dns.RR{
 				test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 			},
 			Extra: []dns.RR{
-				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
-				test.A("svc-2-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.101"),
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
+				test.A("svc-2-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.101"),
 			},
 		},
 	}
@@ -110,10 +110,10 @@ func TestParseDigResponse2(t *testing.T) {
 ;svc-1-a.test-1.svc.cluster.local. IN	A
 
 ;; ANSWER SECTION:
-svc-1-a.test-1.svc.cluster.local. 5 IN	A	10.0.0.100
+svc-1-a.test-1.svc.cluster.local. 5 IN	A	10.96.0.100
 
 ;; Query time: 0 msec
-;; SERVER: 10.0.0.10#53(10.0.0.10)
+;; SERVER: 10.96.0.10#53(10.96.0.10)
 ;; WHEN: Tue Jun 05 13:53:41 UTC 2018
 ;; MSG SIZE  rcvd: 89
 `
@@ -123,7 +123,7 @@ svc-1-a.test-1.svc.cluster.local. 5 IN	A	10.0.0.100
 			Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.96.0.100"),
 			},
 		},
 	}

--- a/test/kubernetes/tools_test.go
+++ b/test/kubernetes/tools_test.go
@@ -53,7 +53,8 @@ svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.101
 ;; Query time: 4 msec
 ;; SERVER: 64.207.129.21#53(64.207.129.21)
 ;; WHEN: Thu Aug  7 16:49:35 2008
-;; MSG SIZE  rcvd: 48`
+;; MSG SIZE  rcvd: 48
+`
 
 	tcs := []test.Case{
 		{
@@ -92,4 +93,45 @@ svc-2-a.test-1.svc.cluster.local.		5	IN	A	10.0.0.101
 	test.SortAndCheck(t, ms[0], tcs[0])
 	test.SortAndCheck(t, ms[1], tcs[1])
 
+}
+
+func TestParseDigResponse2(t *testing.T) {
+
+	r := `; <<>> DiG 9.11.1-P1 <<>> -t A svc-1-a.test-1.svc.cluster.local. +search +showsearch +time=10 +tries=6
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 8093
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+; COOKIE: 9de6109c19064e7c (echoed)
+;; QUESTION SECTION:
+;svc-1-a.test-1.svc.cluster.local. IN	A
+
+;; ANSWER SECTION:
+svc-1-a.test-1.svc.cluster.local. 5 IN	A	10.0.0.100
+
+;; Query time: 0 msec
+;; SERVER: 10.0.0.10#53(10.0.0.10)
+;; WHEN: Tue Jun 05 13:53:41 UTC 2018
+;; MSG SIZE  rcvd: 89
+`
+
+	tcs := []test.Case{
+		{
+			Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			},
+		},
+	}
+
+	ms, err := ParseDigResponse(r)
+	if err != nil {
+		t.Fatalf("failed test: %s", err)
+	}
+
+	test.SortAndCheck(t, ms[0], tcs[0])
 }


### PR DESCRIPTION
Update minikube to latest.
Update to k8s 1.10...

minikube changes:
1. CIDR range is now 10.96.0.0/25 (test cases updated to reflect this)
2. kubeadm is now used by minikube instead of localkube (some adjustments reqd)
 