### PR TITLE
Add tests for configmap translation

### DIFF
--- a/test/k8sdeployment/configmap_test.go
+++ b/test/k8sdeployment/configmap_test.go
@@ -1,0 +1,70 @@
+package k8sdeployment
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/coredns/ci/test/kubernetes"
+	"strings"
+)
+
+func TestConfigMapTranslation(t *testing.T) {
+	//feddata := `{"foo" : "foo.fed.com", "bar.com" : "bar.fed.com"}`
+	feddata := ""
+	stubdata := `{"abc.com" : ["1.2.3.4:5300","4.4.4.4"], "my.cluster.local" : ["2.3.4.5:5300"]}`
+	upstreamdata := `["8.8.8.8", "8.8.4.4"]`
+
+	corefileExpected := `.:53 {
+    errors
+    health
+    kubernetes cluster.local  10.96.0.0/8 172.17.0.0/16 {
+      pods insecure
+      upstream
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    federation {
+      foo foo.fed.com
+      bar.com bar.fed.com
+    }
+    prometheus :9153
+    proxy . 8.8.8.8 8.8.4.4
+    cache 30
+    reload
+    loadbalance
+}
+abc.com:53 {
+  errors
+  cache 30
+  proxy . 1.2.3.4:5300
+}
+
+my.cluster.local:53 {
+  errors
+  cache 30
+  proxy . 2.3.4.5:5300
+}`
+
+	err := kubernetes.LoadKubednsConfigmap(feddata, stubdata, upstreamdata)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+
+	// Apply Corefile translation via coredns/deployment deployment script
+	path := os.Getenv("DEPLOYMENTPATH")
+	cmd := exec.Command("sh", "-c", "./deploy.sh -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+	cmd.Dir = path + "/kubernetes"
+	cmdout, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("deployment script failed: %s\nerr: %s", string(cmdout), err)
+	}
+
+	corefileTranslated, err := kubernetes.Kubectl("-n kube-system get configmap coredns -ojsonpath={.data.Corefile}")
+	if err != nil {
+		t.Fatalf("error fetching translated corefile: %s", err)
+	}
+
+	if strings.Compare(corefileTranslated, corefileExpected) == 0 {
+		t.Fatalf("failed test: Translation does not match")
+	}
+}

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -69,7 +69,7 @@ func TestKubernetesDeployment(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
 		path := os.Getenv("DEPLOYMENTPATH")
-		cmd := exec.Command("sh", "-c", "./deploy.sh  -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+		cmd := exec.Command("sh", "-c", "./deploy.sh -s -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
Test the deploy script part which handles the ConfigMap translation from kube-dns to CoreDNS