### PR TITLE
kubernetes: Add new objects test

### DIFF
--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -176,6 +176,7 @@ func TestKubernetesA(t *testing.T) {
 	}
 
 	newObjectsFile, rmFunc, err := intTest.TempFile(os.TempDir(), newObjects)
+	defer rmFunc()
 	if err != nil {
 		t.Fatalf("could not create file to add service/endpoint: %s", err)
 	}

--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -200,7 +200,7 @@ func TestKubernetesA(t *testing.T) {
 		})
 	}
 
-	_, err = Kubectl("-n test-1 delete service new-service")
+	_, err = Kubectl("-n test-1 delete service new-svc")
 	if err != nil {
 		t.Fatalf("could not add service/endpoint via kubectl: %s", err)
 	}

--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -180,13 +180,13 @@ func TestKubernetesA(t *testing.T) {
 		t.Fatalf("could not create file to add service/endpoint: %s", err)
 	}
 
-	_, err = Kubectl("-n apply -f " + newObjectsFile)
+	_, err = Kubectl("apply -f " + newObjectsFile)
 	if err != nil {
 		t.Fatalf("could not add service/endpoint via kubectl: %s", err)
 	}
 
-	t.Run("New Objects", func(t *testing.T) {
-		for _, tc := range newObjectTests {
+	for _, tc := range newObjectTests {
+		t.Run("New Object "+tc.Qname, func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
 				t.Errorf(err.Error())
@@ -196,7 +196,7 @@ func TestKubernetesA(t *testing.T) {
 			if t.Failed() {
 				t.Errorf("coredns log: %s", CorednsLogs())
 			}
-		}
-	})
+		})
+	}
 
 }

--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -200,4 +200,8 @@ func TestKubernetesA(t *testing.T) {
 		})
 	}
 
+	_, err = Kubectl("-n test-1 delete service new-service")
+	if err != nil {
+		t.Fatalf("could not add service/endpoint via kubectl: %s", err)
+	}
 }

--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -104,7 +104,7 @@ var newObjectTests = []test.Case{
 		Qname: "172-17-0-222.new-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("172-17-0-222.new-svc.test-1.svc.cluster.local.      5    IN      A       10.96.0.222"),
+			test.A("172-17-0-222.new-svc.test-1.svc.cluster.local.      5    IN      A       172.17.0.222"),
 		},
 	},
 }


### PR DESCRIPTION
Add tests that...
* add a new service and endpoints objects after CoreDNS is started
* verify that CoreDNS responds with records for those objects.