### PR TITLE
force kubeadm reset

### DIFF
--- a/build/kubernetes/minikube_teardown.sh
+++ b/build/kubernetes/minikube_teardown.sh
@@ -7,7 +7,7 @@ kill -9 `cat /var/run/kubectl_proxy.pid`
 
 # delete minikube instance
 minikube delete
-kubeadm reset
+kubeadm reset -f
 
 # Delete the docker image repository
 docker stop registry


### PR DESCRIPTION
New version of `kubeadm` interactively asks if you are sure when doing a `kubeadm reset` (even when scripted), passing `-f` forces reset without "are you sure".