### PR TITLE
ignore ttl in test case

### DIFF
--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -72,7 +72,7 @@ var dnsTestCasesA = []test.Case{
 		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
-			test.SOA("cluster.local.        30     IN      SOA     ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 30"),
+			test.SOA("cluster.local.        303     IN      SOA     ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 30"),
 		},
 	},
 	{ // A TXT request for dns-version should return the version of the kubernetes service discovery spec implemented


### PR DESCRIPTION
One test was checking a negative response ttl, all others use `303` to skip the check.
Making this one match the others for consistency, for now.
We may opt to not skip ttl checks in the future, although, that would be somewhat redundant with the unit tests, which already validate ttl.