### PR TITLE
Update Minikube and Kubernetes version

### DIFF
--- a/build/kubernetes/minikube_install.sh
+++ b/build/kubernetes/minikube_install.sh
@@ -2,8 +2,8 @@
 set -v
 
 # Install minikube and kubectl
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.27.0/minikube-linux-amd64 && chmod +x minikube
-curl -Lo kubectl  https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x kubectl
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.33.1/minikube-linux-amd64 && chmod +x minikube
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl
 mv ./minikube /usr/local/bin/
 mv ./kubectl /usr/local/bin/
 

--- a/build/kubernetes/minikube_setup.sh
+++ b/build/kubernetes/minikube_setup.sh
@@ -18,7 +18,7 @@ export KUBECONFIG=$HOME/.kube/config
 
 minikube start --vm-driver=none --kubernetes-version=v1.13.3
 
-# Wait for minkube's api service to be ready
+# Wait for Minikube's api service to be ready
 for i in {1..60} # timeout for 2 minutes
 do
    kubectl get po

--- a/build/kubernetes/minikube_setup.sh
+++ b/build/kubernetes/minikube_setup.sh
@@ -16,7 +16,7 @@ touch $HOME/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
 
-minikube start --vm-driver=none --kubernetes-version=v1.12.0
+minikube start --vm-driver=none --kubernetes-version=v1.13.3
 
 # Wait for minkube's api service to be ready
 for i in {1..60} # timeout for 2 minutes
@@ -27,9 +27,6 @@ do
   fi
   sleep 2
 done
-
-# Disable add-on manager
-minikube addons disable addon-manager
 
 #delete default coredns and deployment
 kubectl delete deployment coredns -n kube-system


### PR DESCRIPTION
Updates Minikube version to v0.33.1 - We no longer need to be bothered by the addon manager since DNS is removed from there.

Updates Kubernetes to v1.13.3 