### PR TITLE
Add test to check connection to the apiserver

### DIFF
--- a/test/k8sdeployment/connection_test.go
+++ b/test/k8sdeployment/connection_test.go
@@ -24,7 +24,10 @@ func TestConnectionAfterAPIRestart(t *testing.T) {
 	}
 
 	// Restart the Kubernetes APIserver and wait for it to come back up.
-	cmd = exec.Command("sh", "-c", "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }' > /dev/null")
+	dockerCmd, err := exec.Command("sh", "-c", "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }' > /dev/null").CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker container restart failed: %s\nerr: %s", string(dockerCmd), err)
+	}
 	time.Sleep(10 * time.Second)
 
 	// Get the restart count of the CoreDNS pods.

--- a/test/k8sdeployment/connection_test.go
+++ b/test/k8sdeployment/connection_test.go
@@ -23,9 +23,9 @@ func TestConnectionAfterAPIRestart(t *testing.T) {
 		t.Fatalf("deployment script failed: %s\nerr: %s", string(cmdout), err)
 	}
 
-	// Restart the Kubernetes APIserver
+	// Restart the Kubernetes APIserver and wait for it to come back up.
 	cmd = exec.Command("sh", "-c", "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }' > /dev/null")
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	// Get the restart count of the CoreDNS pods.
 	restartCount, err := kubernetes.Kubectl("-n kube-system get pods -l k8s-app=kube-dns -ojsonpath='{.items[*].status.containerStatuses[0].restartCount}'")

--- a/test/k8sdeployment/connection_test.go
+++ b/test/k8sdeployment/connection_test.go
@@ -1,0 +1,40 @@
+package k8sdeployment
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coredns/ci/test/kubernetes"
+)
+
+// This test restarts the kube-APIserver and checks if CoreDNS connection to the API
+// is valid and there are no failures.
+// This test is to catch bugs/errors such as the one reported in https://github.com/coredns/coredns/issues/2464
+func TestConnectionAfterAPIRestart(t *testing.T) {
+	// Apply manifests via coredns/deployment deployment script ...
+	path := os.Getenv("DEPLOYMENTPATH")
+	cmd := exec.Command("sh", "-c", "./deploy.sh -s -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+	cmd.Dir = path + "/kubernetes"
+	cmdout, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("deployment script failed: %s\nerr: %s", string(cmdout), err)
+	}
+
+	// Restart the Kubernetes APIserver
+	cmd = exec.Command("sh", "-c", "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }' > /dev/null")
+	time.Sleep(5 * time.Second)
+
+	// Get the restart count of the CoreDNS pods.
+	restartCount, err := kubernetes.Kubectl("-n kube-system get pods -l k8s-app=kube-dns -ojsonpath='{.items[*].status.containerStatuses[0].restartCount}'")
+	if err != nil {
+		t.Fatalf("error fetching CoreDNS pod restart count: %s", err)
+	}
+
+	// If CoreDNS crashes due to KubeAPIServer restart, Kubernetes will restart the CoreDNS containers.
+	if !strings.Contains(restartCount, "0") {
+		t.Fatalf("failed as CoreDNS crashed due to KubeAPIServer restart.")
+	}
+}

--- a/test/k8sdeployment/connection_test.go
+++ b/test/k8sdeployment/connection_test.go
@@ -24,7 +24,7 @@ func TestConnectionAfterAPIRestart(t *testing.T) {
 	}
 
 	// Restart the Kubernetes APIserver and wait for it to come back up.
-	dockerCmd, err := exec.Command("sh", "-c", "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }' > /dev/null").CombinedOutput()
+	dockerCmd, err := exec.Command("sh", "-c", "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }') > /dev/null").CombinedOutput()
 	if err != nil {
 		t.Fatalf("docker container restart failed: %s\nerr: %s", string(dockerCmd), err)
 	}

--- a/test/k8sdeployment/connection_test.go
+++ b/test/k8sdeployment/connection_test.go
@@ -28,7 +28,7 @@ func TestConnectionAfterAPIRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("docker container restart failed: %s\nerr: %s", string(dockerCmd), err)
 	}
-	time.Sleep(10 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	// Get the restart count of the CoreDNS pods.
 	restartCount, err := kubernetes.Kubectl("-n kube-system get pods -l k8s-app=kube-dns -ojsonpath='{.items[*].status.containerStatuses[0].restartCount}'")

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -281,6 +281,20 @@ func CoreDNSPodIPs() ([]string, error) {
 	return ips, nil
 }
 
+// HasCoreDNSRestarted verifies if any of the CoreDNS containers has restarted.
+func HasCoreDNSRestarted() (bool, error) {
+	restartCount, err := Kubectl("-n kube-system get pods -l k8s-app=kube-dns -ojsonpath='{.items[*].status.containerStatuses[0].restartCount}'")
+	if err != nil {
+		return false, err
+	}
+
+	if !strings.Contains(restartCount, "0") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // Kubectl executes the kubectl command with the given arguments
 func Kubectl(args string) (result string, err error) {
 	kctl := os.Getenv("KUBECTL")


### PR DESCRIPTION
Adds test to ensure coredns does not crash when the apiserver is restarted. 
This test validates https://github.com/coredns/deployment/pull/138 and catch issues like https://github.com/coredns/coredns/issues/2464