### PR TITLE
Cleanup deployment test

### DIFF
--- a/test/k8sdeployment/configmap_test.go
+++ b/test/k8sdeployment/configmap_test.go
@@ -70,4 +70,10 @@ my.cluster.local:53 {
 	if strings.Compare(corefileTranslated, corefileExpected) != 0 {
 		t.Fatalf("failed test: Translation does not match")
 	}
+
+	// Clean-up by removing kube-dns ConfigMap
+	_, err = kubernetes.Kubectl("-n kube-system delete cm kube-dns")
+	if err != nil {
+		t.Fatalf("error deleting kube-dns ConfigMap: %s", err)
+	}
 }

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -69,7 +69,7 @@ func TestKubernetesDeployment(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
 		path := os.Getenv("DEPLOYMENTPATH")
-		cmd := exec.Command("sh", "-c", "./deploy.sh -s -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
+		cmd := exec.Command("sh", "-c", "./deploy.sh -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 		cmd.Dir = path + "/kubernetes"
 		cmdout, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
- Remove the kube-dns ConfigMap after testing translation using deploy script.
- Remove `-s` option for cases in https://github.com/coredns/deployment/pull/144 where it's more common to have no kube-dns configmap.



/cc @chrisohaver 