### PR TITLE
kubernetai tests: proxy removed, use forward

### DIFF
--- a/test/kubernetai/autopath_test.go
+++ b/test/kubernetai/autopath_test.go
@@ -101,7 +101,7 @@ internal.		IN	SOA	sns.internal. noc.internal. 2015082541 7200 3600 1209600 3600
             pods verified
         }
         file /etc/coredns/Zonefile example.net
-        proxy internal ` + udp + `
+        forward internal ` + udp + `
     }
 `
 	exampleZonefile := `    ; example.net zone info for autopath tests


### PR DESCRIPTION
The proxy plugin was removed from CoreDNS; use forward plugin instead.