### PR TITLE
Add benchmarks tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
     steps:
       - <<: *initWorkingDir
       - checkout
+      - <<: *buildCoreDNSImage
       - run:
           name: Run CoreDNS Benchmarks
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,15 @@ buildMetadataEdns0Image: &buildMetadataEdns0Image
         docker push localhost:5000/coredns
 
 jobs:
+  coredns-benchmark-tests:
+    steps:
+      - <<: *initWorkingDir
+      - checkout
+      - run:
+          name: Run CoreDNS Benchmarks
+          command: |
+            cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
+            go test -v -bench=.  ./...
   kubernetes-tests:
     <<: *integrationDefaults
     steps:
@@ -135,6 +144,7 @@ workflows:
   version: 2
   integration-tests:
     jobs:
+      - coredns-benchmark-tests
       - kubernetes-tests
       - k8s-deployment-tests
       - external-plugin-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ buildMetadataEdns0Image: &buildMetadataEdns0Image
 
 jobs:
   coredns-benchmark-tests:
+    <<: *integrationDefaults
     steps:
       - <<: *initWorkingDir
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,11 @@ jobs:
     steps:
       - <<: *initWorkingDir
       - checkout
-      - <<: *buildCoreDNSImage
+      - run:
+          name: Clone CoreDNS repo
+          command: |
+            mkdir -p ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
+            git clone https://github.com/${CIRCLE_PROJECT_USERNAME}/coredns ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
       - run:
           name: Run CoreDNS Benchmarks
           command: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ci
+# ci 
 
 Repository for continuous integration tests for the CoreDNS project. Currently tests relating to Kubernetes are contained here, but integration tests for other internal CoreDNS plugins may be moved here or added here in the future. 
 The repository also contains tests related to Kubernetes Deployment and external plugins (kubernetai, metadata_edns0).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ci 
+# ci
 
 Repository for continuous integration tests for the CoreDNS project. Currently tests relating to Kubernetes are contained here, but integration tests for other internal CoreDNS plugins may be moved here or added here in the future. 
 The repository also contains tests related to Kubernetes Deployment and external plugins (kubernetai, metadata_edns0).


### PR DESCRIPTION
Enables running CoreDNS benchmark tests on CircleCI
Tested that it successfully runs on https://github.com/rajansandeep/ci/pull/1