### PR TITLE
remove kubernetes related option

### DIFF
--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -57,7 +57,7 @@ var dnsTestCasesA = []test.Case{
 			test.A("*.test-1.svc.cluster.local.      303    IN      A       172.17.0.254"),
 			test.A("*.test-1.svc.cluster.local.      303    IN      A       172.17.0.255"),
 			test.CNAME("*.test-1.svc.cluster.local.  303    IN      CNAME   example.net."),
-			// test.A("example.net.                     303    IN      A       13.14.15.16"), // Not resolved because no proxy is defined.
+			test.A("example.net.                     303    IN      A       13.14.15.16"),
 		},
 	},
 	{ // A wild card service name in an un-exposed namespace result in nxdomain
@@ -146,9 +146,9 @@ func TestKubernetesA(t *testing.T) {
         errors
         log
         kubernetes cluster.local 10.in-addr.arpa {
-            namespaces test-1
-            upstream ` + udp + `
-        }
+			namespaces test-1
+		}
+		forward . ` + udp + `
     }
 `
 

--- a/test/kubernetes/fallthrough_test.go
+++ b/test/kubernetes/fallthrough_test.go
@@ -56,7 +56,6 @@ func TestKubernetesFallthrough(t *testing.T) {
 	defer rmFunc()
 
 	time.Sleep(1 * time.Second)
-
 	corefile := `    .:53 {
       health
       ready
@@ -65,7 +64,6 @@ func TestKubernetesFallthrough(t *testing.T) {
       file /etc/coredns/Zonefile cluster.local
       kubernetes cluster.local {
           namespaces test-1
-          upstream ` + udp + `
           fallthrough
       }
       forward . ` + udp + `
@@ -120,13 +118,6 @@ var dnsTestCasesFallthroughFiltered = []test.Case{
 }
 
 func TestKubernetesFallthroughFiltered(t *testing.T) {
-
-	rmFunc, upstream, udp := UpstreamServer(t, "example.net", ExampleNet)
-	defer upstream.Stop()
-	defer rmFunc()
-
-	time.Sleep(1 * time.Second)
-
 	corefile := `    .:53 {
       health
       ready
@@ -135,7 +126,6 @@ func TestKubernetesFallthroughFiltered(t *testing.T) {
       file /etc/coredns/Zonefile cluster.local
       kubernetes cluster.local {
           namespaces test-1
-          upstream ` + udp + `
           fallthrough svc.cluster.local
       }
     }

--- a/test/kubernetes/srv_test.go
+++ b/test/kubernetes/srv_test.go
@@ -171,8 +171,8 @@ func TestKubernetesSRV(t *testing.T) {
 	    log
         kubernetes cluster.local {
             namespaces test-1
-            upstream ` + udp + `
-        }
+		}
+		forward . ` + udp + `
     }
 `
 


### PR DESCRIPTION
Signed-off-by: Zou Nengren <zouyee1989@gmail.com>

**notes for reviewer:**

```
Also re-enabled and adjusted the kubernetes upstream behavior test to verify default upstream 
behavior. The test had been commented out when the upstream option was originally deprecated.
```