### PR TITLE
Fix and re-enable skipped tests

### DIFF
--- a/build/kubernetes/k8s_setup.sh
+++ b/build/kubernetes/k8s_setup.sh
@@ -24,7 +24,3 @@ kubectl patch deployment coredns -n kube-system -p "$(cat ~/go/src/${CIRCLE_PROJ
 
 # Deploy test objects
 kubectl create -f ~/go/src/${CIRCLE_PROJECT_USERNAME}/ci/build/kubernetes/dns-test.yaml
-
-# Add federation labels to node
-kubectl label nodes kind-control-plane failure-domain.beta.kubernetes.io/zone=fdzone
-kubectl label nodes kind-control-plane failure-domain.beta.kubernetes.io/region=fdregion

--- a/test/k8sdeployment/connection_test.go
+++ b/test/k8sdeployment/connection_test.go
@@ -1,6 +1,7 @@
 package k8sdeployment
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -11,10 +12,6 @@ import (
 // is valid and there are no failures.
 // This test is to catch bugs/errors such as the one reported in https://github.com/coredns/coredns/issues/2464
 func TestConnectionAfterAPIRestart(t *testing.T) {
-
-	t.Skip("Test needs to be refactored for kind environment")
-	return
-
 	// Apply manifests via coredns/deployment deployment script ...
 	cmd := exec.Command("sh", "-c", " ~/go/src/${CIRCLE_PROJECT_USERNAME}/deployment/kubernetes/deploy.sh -s -i 10.96.0.10 -r 10.96.0.0/8 -r 172.17.0.0/16 | kubectl apply -f -")
 	cmdout, err := cmd.CombinedOutput()
@@ -29,33 +26,49 @@ func TestConnectionAfterAPIRestart(t *testing.T) {
 	}
 
 	// Check if CoreDNS has restarted before the APIServer restart
-	restartCount, err := kubernetes.HasCoreDNSRestarted()
+	hasCoreDNSRestarted, err := kubernetes.HasResourceRestarted(kubernetes.CoreDNSLabel)
 	if err != nil {
 		t.Fatalf("error fetching CoreDNS pod restart count: %s", err)
 	}
-	if restartCount {
+	if hasCoreDNSRestarted {
 		t.Fatalf("error as CoreDNS has crashed: %s.", kubernetes.CorednsLogs())
 	}
 
 	// Restart the Kubernetes APIServer.
-	dockerCmd, err := exec.Command("sh", "-c", "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }') > /dev/null").CombinedOutput()
+	containerID, err := kubernetes.FetchDockerContainerID("kind-control-plane")
 	if err != nil {
-		t.Fatalf("docker container restart failed: %s\nerr: %s", string(dockerCmd), err)
+		t.Fatalf("docker container ID not found, err: %s", err)
 	}
+
+	dockerCmd := fmt.Sprintf("docker exec -i %s /bin/sh -c \"pkill kube-apiserver\"", containerID)
+	killAPIServer, err := exec.Command("sh", "-c", dockerCmd).CombinedOutput()
+	if err != nil {
+		t.Fatalf("API Server restart failed: %s\nerr: %s", string(killAPIServer), err)
+	}
+
 	// Verify that the CoreDNS pods are up and ready after the restart.
 	maxWait = 120
 	if kubernetes.WaitNReady(maxWait, 1) != nil {
 		t.Fatalf("coredns failed to start in %v seconds,\nlog: %v", maxWait, kubernetes.CorednsLogs())
 	}
 
+	// Check if the api-server was actually restarted
+	hasAPIRestarted, err := kubernetes.HasResourceRestarted(kubernetes.APIServerLabel)
+	if err != nil {
+		t.Fatalf("error fetching kube-apiserver pod restart count: %s", err)
+	}
+	if !hasAPIRestarted {
+		t.Fatalf("API Server restart failed")
+	}
+
 	// Check if CoreDNS has crashed after APIServer restart
-	restartCount, err = kubernetes.HasCoreDNSRestarted()
+	hasCoreDNSRestarted, err = kubernetes.HasResourceRestarted(kubernetes.CoreDNSLabel)
 	if err != nil {
 		t.Fatalf("error fetching CoreDNS pod restart count: %s", err)
 	}
 
 	// If CoreDNS crashes due to KubeAPIServer restart, Kubernetes will restart the CoreDNS containers.
-	if restartCount {
+	if hasCoreDNSRestarted {
 		t.Fatalf("failed as CoreDNS crashed due to KubeAPIServer restart.")
 	}
 }

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -277,17 +277,21 @@ func HasResourceRestarted(label string) (bool, error) {
 	wait := 5
 
 	for {
+		hasRestarted := false
 		restartCount, err := Kubectl(fmt.Sprintf("-n kube-system get pods -l %s -ojsonpath='{.items[*].status.containerStatuses[0].restartCount}'", label))
 		if err != nil {
 			return false, err
 		}
 		individualCount := strings.Split(restartCount, " ")
 		for _, count := range individualCount {
-			if count == "0" {
-				break
+			if count != "0" {
+				hasRestarted = true
 			}
 		}
 
+		if !hasRestarted {
+			break
+		}
 		time.Sleep(time.Second)
 		wait--
 		if wait == 0 {

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -281,9 +281,13 @@ func HasResourceRestarted(label string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if !strings.Contains(restartCount, "0") {
-			break
+		individualCount := strings.Split(restartCount, " ")
+		for _, count := range individualCount {
+			if count == "0" {
+				break
+			}
 		}
+
 		time.Sleep(time.Second)
 		wait--
 		if wait == 0 {

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -289,7 +289,7 @@ func HasResourceRestarted(label string) (bool, error) {
 			}
 		}
 
-		if !hasRestarted {
+		if hasRestarted {
 			break
 		}
 		time.Sleep(time.Second)

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -101,7 +101,7 @@ func StartClientPod(namespace string) error {
 			break
 		}
 	}
-	return errors.New("timeout waiting for " + clientName + " to be ready.")
+	return errors.New("timeout waiting for " + clientName + " to be ready")
 
 }
 
@@ -271,18 +271,41 @@ func CoreDNSPodIPs() ([]string, error) {
 	return ips, nil
 }
 
-// HasCoreDNSRestarted verifies if any of the CoreDNS containers has restarted.
-func HasCoreDNSRestarted() (bool, error) {
-	restartCount, err := Kubectl("-n kube-system get pods -l k8s-app=kube-dns -ojsonpath='{.items[*].status.containerStatuses[0].restartCount}'")
+// HasResourceRestarted verifies if any of the specified containers in the kube-system namespace has restarted.
+func HasResourceRestarted(label string) (bool, error) {
+	// magic number
+	wait := 5
+
+	for {
+		restartCount, err := Kubectl(fmt.Sprintf("-n kube-system get pods -l %s -ojsonpath='{.items[*].status.containerStatuses[0].restartCount}'", label))
+		if err != nil {
+			return false, err
+		}
+		if !strings.Contains(restartCount, "0") {
+			break
+		}
+		time.Sleep(time.Second)
+		wait--
+		if wait == 0 {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// FetchDockerContainerID fetches the docker container ID from the container name
+func FetchDockerContainerID(containerName string) (string, error) {
+	containerID, err := exec.Command("sh", "-c", fmt.Sprintf("docker ps -aqf \"name=%s\"", containerName)).CombinedOutput()
 	if err != nil {
-		return false, err
+		return "", errors.New("error executing docker command to fetch container ID")
 	}
 
-	if !strings.Contains(restartCount, "0") {
-		return true, nil
+	if containerID == nil {
+		return "", errors.New("no containerID found")
 	}
 
-	return false, nil
+	return strings.TrimSpace(string(containerID)), nil
 }
 
 // Kubectl executes the kubectl command with the given arguments
@@ -459,5 +482,7 @@ data:
 example.net.          IN      SOA     ns.example.net. admin.example.net. 2015082541 7200 3600 1209600 3600
 example.net. IN A 13.14.15.16
 `
-	clientName = "coredns-test-client"
+	clientName     = "coredns-test-client"
+	CoreDNSLabel   = "k8s-app=kube-dns"
+	APIServerLabel = "component=kube-apiserver"
 )


### PR DESCRIPTION
Some tests were skipped due to them incompatible with the way `kind` works.
Refactored the tests for them to be working on the `kind` cluster.

