### PR TITLE
kubernetes: Add test for unready endpoints

### DIFF
--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -77,6 +77,30 @@ spec:
           name: c-port
           protocol: UDP
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unready
+  namespace: test-1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-unready
+  template:
+    metadata:
+      labels:
+        app: app-unready
+    spec:
+      containers:
+        - name: app-unready
+          image: invalid-image:0.0
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 1234
+              name: c-port
+              protocol: UDP
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -161,6 +185,20 @@ spec:
   - name: c-port
     port: 1234
     protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-unready
+  namespace: test-1
+spec:
+  selector:
+    app: app-unready
+  clusterIP: None
+  ports:
+    - name: c-port
+      port: 1234
+      protocol: UDP
 ---
 kind: Endpoints
 apiVersion: v1

--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -89,6 +89,13 @@ var dnsTestCasesA = []test.Case{
 			test.AAAA("headless-svc.test-1.svc.cluster.local.      5    IN      AAAA      1234:abcd::2"),
 		},
 	},
+	{ // A query to a headless service with unready endpoints should return NXDOMAIN
+		Qname: "svc-unready.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.        303     IN      SOA     ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 30"),
+		},
+	},
 }
 
 var newObjectTests = []test.Case{


### PR DESCRIPTION
Adds a headless service and deployment with pods that never download an image, so that they stay perpetually unready.
Adds a test that verifies a query for the headless service selecting the unready pods will return nxdomain.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>