### PR TITLE
Remove flaking test

### DIFF
--- a/test/kubernetes/srv_test.go
+++ b/test/kubernetes/srv_test.go
@@ -70,24 +70,27 @@ var dnsTestCasesSRV = []test.Case{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
-	{
-		Qname: "_c-port._UDP.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.        303       IN      SRV     0 20 1234 1234-abcd--1.headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.        303       IN      SRV     0 20 1234 1234-abcd--2.headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 20 1234 172-17-0-254.headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 20 1234 172-17-0-255.headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 20 1234 svc-c.test-1.svc.cluster.local."),
+	// The following test flakes due to inconsistent SRV weight returned in CI env. Cannot reproduce this locally.
+	/*
+		{
+			Qname: "_c-port._UDP.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.        303       IN      SRV     0 20 1234 1234-abcd--1.headless-svc.test-1.svc.cluster.local."),
+				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.        303       IN      SRV     0 20 1234 1234-abcd--2.headless-svc.test-1.svc.cluster.local."),
+				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 20 1234 172-17-0-254.headless-svc.test-1.svc.cluster.local."),
+				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 20 1234 172-17-0-255.headless-svc.test-1.svc.cluster.local."),
+				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 20 1234 svc-c.test-1.svc.cluster.local."),
+			},
+			Extra: []dns.RR{
+				test.AAAA("1234-abcd--1.headless-svc.test-1.svc.cluster.local.     303       IN      AAAA    1234:abcd::1"),
+				test.AAAA("1234-abcd--2.headless-svc.test-1.svc.cluster.local.     303       IN      AAAA    1234:abcd::2"),
+				test.A("172-17-0-254.headless-svc.test-1.svc.cluster.local.	303	IN	A	172.17.0.254"),
+				test.A("172-17-0-255.headless-svc.test-1.svc.cluster.local.	303	IN	A	172.17.0.255"),
+				test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.96.0.115"),
+			},
 		},
-		Extra: []dns.RR{
-			test.AAAA("1234-abcd--1.headless-svc.test-1.svc.cluster.local.     303       IN      AAAA    1234:abcd::1"),
-			test.AAAA("1234-abcd--2.headless-svc.test-1.svc.cluster.local.     303       IN      AAAA    1234:abcd::2"),
-			test.A("172-17-0-254.headless-svc.test-1.svc.cluster.local.	303	IN	A	172.17.0.254"),
-			test.A("172-17-0-255.headless-svc.test-1.svc.cluster.local.	303	IN	A	172.17.0.255"),
-			test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.96.0.115"),
-		},
-	},
+	*/
 	{
 		Qname: "*._tcp.any.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,


### PR DESCRIPTION

One wildcard SRV test flakes occasionally. I cannot reproduce the failure locally.  Seems to be some oddity with the test environment. Removing.

Closes #140

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>