### PR TITLE
kubernetes: add endpoint_pod_names test

### DIFF
--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -266,4 +266,83 @@ spec:
   - name: c-port
     port: 1234
     protocol: UDP
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-1
+  namespace: test-3
+spec:
+  selector:
+    app: headless-1
+  clusterIP: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-1
+  namespace: test-3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headless-1
+  template:
+    metadata:
+      labels:
+        app: headless-1
+    spec:
+      containers:
+        - name: test-pod-name
+          image: gcr.io/google_containers/pause-amd64:3.0
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-1
+  namespace: test-3
+spec:
+  selector:
+    app: headless-2
+  clusterIP: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-2
+  namespace: test-3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headless-2
+  template:
+    metadata:
+      labels:
+        app: headless-2
+    spec:
+      containers:
+        - name: test-pod-name-longer-than-63-characters-making-it-an-invalid-dns-label
+          image: gcr.io/google_containers/pause-amd64:3.0
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
 

--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -289,7 +289,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: deployment-1
+  name: test-name
   namespace: test-3
 spec:
   replicas: 1
@@ -302,7 +302,7 @@ spec:
         app: headless-1
     spec:
       containers:
-        - name: test-pod-name
+        - name: pause
           image: gcr.io/google_containers/pause-amd64:3.0
           ports:
             - containerPort: 80
@@ -326,7 +326,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: deployment-2
+  name: test-name-longer-than-63-characters-making-it-an-invalid-dns-label
   namespace: test-3
 spec:
   replicas: 1
@@ -339,7 +339,7 @@ spec:
         app: headless-2
     spec:
       containers:
-        - name: test-pod-name-longer-than-63-characters-making-it-an-invalid-dns-label
+        - name: pause
           image: gcr.io/google_containers/pause-amd64:3.0
           ports:
             - containerPort: 80

--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -286,28 +286,21 @@ spec:
       port: 80
       protocol: TCP
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Pod
 metadata:
   name: test-name
   namespace: test-3
+  labels:
+    app: headless-1
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: headless-1
-  template:
-    metadata:
-      labels:
-        app: headless-1
-    spec:
-      containers:
-        - name: pause
-          image: gcr.io/google_containers/pause-amd64:3.0
-          ports:
-            - containerPort: 80
-              name: http
-              protocol: TCP
+  containers:
+    - name: pause
+      image: gcr.io/google_containers/pause-amd64:3.0
+      ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
 ---
 apiVersion: v1
 kind: Service
@@ -323,26 +316,18 @@ spec:
       port: 80
       protocol: TCP
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Pod
 metadata:
   name: test-name-longer-than-63-characters-making-it-an-invalid-dns-label
   namespace: test-3
+  labels:
+    app: headless-2
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: headless-2
-  template:
-    metadata:
-      labels:
-        app: headless-2
-    spec:
-      containers:
-        - name: pause
-          image: gcr.io/google_containers/pause-amd64:3.0
-          ports:
-            - containerPort: 80
-              name: http
-              protocol: TCP
-
+  containers:
+    - name: pause
+      image: gcr.io/google_containers/pause-amd64:3.0
+      ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP

--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -312,7 +312,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: headless-1
+  name: headless-2
   namespace: test-3
 spec:
   selector:

--- a/test/kubernetes/endpoints_test.go
+++ b/test/kubernetes/endpoints_test.go
@@ -19,7 +19,7 @@ func TestKubernetesEndpointPodNames(t *testing.T) {
 			Case:        test.Case{Qname: "headless-1.test-3.svc.cluster.local.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess},
 			AnswerCount: 1,
 			ExtraCount:  1,
-			TargetRegEx: "^test-name-.+\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
+			TargetRegEx: "^test-name\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
 		},
 		{
 			Case:        test.Case{Qname: "headless-2.test-3.svc.cluster.local.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess},

--- a/test/kubernetes/endpoints_test.go
+++ b/test/kubernetes/endpoints_test.go
@@ -26,7 +26,7 @@ func TestKubernetesEndpointPodNames(t *testing.T) {
 			AnswerCount: 1,
 			ExtraCount:  1,
 			// The pod name selected by headless-2 exceeds the valid dns label length, so it should fallback to the dashed-ip
-			TargetRegEx: "^[0-9]+-[0-9]+-[0-9]+-[0-9]+\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
+			TargetRegEx: "^[0-9]+-[0-9]+-[0-9]+-[0-9]+\\.headless-2\\.test-3\\.svc\\.cluster\\.local\\.$",
 		},
 	}
 

--- a/test/kubernetes/endpoints_test.go
+++ b/test/kubernetes/endpoints_test.go
@@ -25,6 +25,7 @@ func TestKubernetesEndpointPodNames(t *testing.T) {
 			Case:        test.Case{Qname: "headless-2.test-3.svc.cluster.local.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess},
 			AnswerCount: 1,
 			ExtraCount:  1,
+			// The pod name selected by headless-2 exceeds the valid dns label length, so it should fallback to the dashed-ip
 			TargetRegEx: "^[0-9]+-[0-9]+-[0-9]+-[0-9]+\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
 		},
 	}

--- a/test/kubernetes/endpoints_test.go
+++ b/test/kubernetes/endpoints_test.go
@@ -1,0 +1,92 @@
+package kubernetes
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/miekg/dns"
+)
+
+func TestKubernetesEndpointPodNames(t *testing.T) {
+	var tests = []struct {
+		test.Case
+		TargetRegEx             string
+		AnswerCount, ExtraCount int
+	}{
+		{
+			Case:        test.Case{Qname: "headless-1.test-3.svc.cluster.local.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess},
+			AnswerCount: 1,
+			ExtraCount:  1,
+			TargetRegEx: "^test-pod-name\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
+		},
+		{
+			Case:        test.Case{Qname: "headless-2.test-3.svc.cluster.local.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess},
+			AnswerCount: 1,
+			ExtraCount:  1,
+			TargetRegEx: "^[0-9]+-[0-9]+-[0-9]+-[0-9]+\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
+		},
+	}
+
+	// namespace test-3 contains headless services/deployments for this test.
+	// enable endpoint_pod_names in Corefile
+	corefile := `    .:53 {
+        health
+        ready
+        errors
+        log
+        kubernetes cluster.local 10.in-addr.arpa {
+			namespaces test-3
+			endpoint_pod_names
+		}
+    }
+`
+
+	err := LoadCorefile(corefile)
+	if err != nil {
+		t.Fatalf("Could not load corefile: %s", err)
+	}
+	namespace := "test-1"
+	err = StartClientPod(namespace)
+	if err != nil {
+		t.Fatalf("failed to start client pod: %s", err)
+	}
+	for _, expected := range tests {
+		t.Run(fmt.Sprintf("%s %s", expected.Qname, dns.TypeToString[expected.Qtype]), func(t *testing.T) {
+			result, err := DoIntegrationTest(expected.Case, namespace)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			if len(result.Answer) != expected.AnswerCount {
+				t.Errorf("Expected %v answers, got %v.", expected.AnswerCount, len(result.Answer))
+			}
+			if len(result.Extra) != expected.ExtraCount {
+				t.Errorf("Expected %v additionals, got %v.", expected.ExtraCount, len(result.Extra))
+			}
+			if len(result.Answer) > 0 {
+				match, err := regexp.Match(expected.TargetRegEx, []byte(result.Answer[0].(*dns.SRV).Target))
+				if err != nil {
+					t.Error(err)
+				}
+				if !match {
+					t.Errorf("Answer target %q did not match regex %q", result.Answer[0].(*dns.SRV).Target, expected.TargetRegEx)
+				}
+			}
+			if len(result.Extra) > 0 {
+				match, err := regexp.Match(expected.TargetRegEx, []byte(result.Extra[0].Header().Name))
+				if err != nil {
+					t.Error(err)
+				}
+				if !match {
+					t.Errorf("Extra name %q did not match regex %q", result.Extra[0].Header().Name, expected.TargetRegEx)
+				}
+			}
+
+			if t.Failed() {
+				t.Errorf("coredns log: %s", CorednsLogs())
+			}
+		})
+	}
+}

--- a/test/kubernetes/endpoints_test.go
+++ b/test/kubernetes/endpoints_test.go
@@ -19,7 +19,7 @@ func TestKubernetesEndpointPodNames(t *testing.T) {
 			Case:        test.Case{Qname: "headless-1.test-3.svc.cluster.local.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess},
 			AnswerCount: 1,
 			ExtraCount:  1,
-			TargetRegEx: "^test-pod-name\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
+			TargetRegEx: "^test-name-.+\\.headless-1\\.test-3\\.svc\\.cluster\\.local\\.$",
 		},
 		{
 			Case:        test.Case{Qname: "headless-2.test-3.svc.cluster.local.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess},


### PR DESCRIPTION
Adds a test for `endpoint_pod_names`.
Includes a test for a long pod name exceeding valid DNS label length.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>