### PR TITLE
Adjust PTR tests and endpoint test fixtures to match new PTR behavior

### DIFF
--- a/build/kubernetes/dns-test.yaml
+++ b/build/kubernetes/dns-test.yaml
@@ -233,9 +233,13 @@ metadata:
 subsets:
   - addresses:
       - ip: 172.17.0.255
+        hostname: foo4a
       - ip: 172.17.0.254
+        hostname: foo4b
       - ip: 1234:abcd::1
+        hostname: foo6a
       - ip: 1234:abcd::2
+        hostname: foo6b
     ports:
       - port: 1234
         name: c-port

--- a/test/kubernetes/ptr_test.go
+++ b/test/kubernetes/ptr_test.go
@@ -10,25 +10,25 @@ import (
 )
 
 var dnsTestCasesPTR = []test.Case{
-	{ // A PTR record query for an existing service should return a record
+	{ // A PTR record query for an existing service Cluster IP should return a record
 		Qname: "100.0.96.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.PTR("100.0.96.10.in-addr.arpa. 303	IN	PTR	svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
-	{ // A PTR record query for an existing endpoint should return a record
-		Qname: "253.0.17.172.in-addr.arpa.", Qtype: dns.TypePTR,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.PTR("253.0.17.172.in-addr.arpa. 303	IN	PTR	172-17-0-253.svc-1-a.test-1.svc.cluster.local."),
-		},
-	},
-	{ // A PTR record query for an existing ipv6 endpoint should return a record
+	{ // A PTR record query for an existing endpoint with a hostname defined should return a record (e.g. Headless service)
 		Qname: "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa.", Qtype: dns.TypePTR,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa. 303 IN PTR 1234-abcd--1.headless-svc.test-1.svc.cluster.local."),
+			test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa. 303 IN PTR foo6a.headless-svc.test-1.svc.cluster.local."),
+		},
+	},
+	{ // A PTR record query for an existing endpoint without a hostname defined should return NXDOMAIN (e.g. Cluster IP service)
+		Qname: "253.0.17.172.in-addr.arpa.", Qtype: dns.TypePTR,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("0.96.10.in-addr.arpa.	303	IN	SOA	ns.dns.0.96.10.in-addr.arpa. hostmaster.0.96.10.in-addr.arpa. 1510339777 7200 1800 86400 30"),
 		},
 	},
 	{ // A PTR record query for an existing service in an UNEXPOSED namespace should return NXDOMAIN


### PR DESCRIPTION
https://github.com/coredns/coredns/pull/6623 changes conditions for PTR creation:

Only Endpoint addresses with hostnames will have corresponding PTR records.
Thus a PTR request for an addresses that matches and Endpoint without a hostname will result in NXDOMAIN.
