### PR TITLE
fix unused format string funcs

### DIFF
--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -37,25 +37,6 @@ var deploymentDNSCases = []test.Case{
 	},
 }
 
-// Fuzzy cases compared for cardinality only
-var deploymentDNSCasesFuzzy = []test.Case{
-	{ // A query for an externalname service should return a CNAME and upstream A record
-		Qname: "ext-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("example.net.      5    IN      A       1.2.3.4"),
-			test.CNAME("ext-svc.test-1.svc.cluster.local.      5    IN      CNAME       example.net."),
-		},
-	},
-	{ // A query for a name outside of k8s zone should get an answer via proxy
-		Qname: "coredns.io.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("coredns.io.      5    IN      A       5.6.7.8"),
-		},
-	},
-}
-
 func TestKubernetesDeploymentDeploys(t *testing.T) {
 	t.Run("Deploy_with_deploy.sh", func(t *testing.T) {
 		// Apply manifests via coredns/deployment deployment script ...
@@ -199,24 +180,6 @@ func TestKubernetesDeploymentDNSQueries(t *testing.T) {
 			}
 			if t.Failed() {
 				t.Errorf("coredns log: %s", kubernetes.CorednsLogs())
-			}
-		})
-	}
-	// Verify dns query test fuzzy cases
-	testCases = deploymentDNSCasesFuzzy
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
-			res, err := kubernetes.DoIntegrationTest(tc, namespace)
-			if err != nil {
-				t.Error(err)
-			}
-			if res == nil {
-				t.Fatalf("got no response")
-			}
-			test.CNAMEOrder(res)
-			// Just compare the cardinality of the response to expected
-			if len(tc.Answer) != len(res.Answer) {
-				t.Errorf("Expected %v answers, got %v. coredns log: %s", len(tc.Answer), len(res.Answer), kubernetes.CorednsLogs())
 			}
 		})
 	}

--- a/test/k8sdeployment/deployment_test.go
+++ b/test/k8sdeployment/deployment_test.go
@@ -188,7 +188,7 @@ func TestKubernetesDeploymentDNSQueries(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := kubernetes.DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if res == nil {
 				t.Fatalf("got no response")

--- a/test/kubernetai/address_test.go
+++ b/test/kubernetai/address_test.go
@@ -83,7 +83,7 @@ func TestKubernetai(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := kubernetes.DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {

--- a/test/kubernetai/axfr_test.go
+++ b/test/kubernetai/axfr_test.go
@@ -192,7 +192,7 @@ cluster.local.		5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1726499
 
 			res, err := kubernetes.DoIntegrationTest(tc.dig, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if res != nil {
 				failures := kubernetes.ValidateAXFR(res.Answer, tc.dig.Answer)

--- a/test/kubernetes/address_test.go
+++ b/test/kubernetes/address_test.go
@@ -156,7 +156,7 @@ func TestKubernetesA(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if res != nil {
 				test.CNAMEOrder(res)
@@ -185,7 +185,7 @@ func TestKubernetesA(t *testing.T) {
 		t.Run("New Object "+tc.Qname, func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {

--- a/test/kubernetes/autopath_test.go
+++ b/test/kubernetes/autopath_test.go
@@ -105,7 +105,7 @@ internal.		IN	SOA	sns.internal. noc.internal. 2015082541 7200 3600 1209600 3600
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if res != nil {
 				test.CNAMEOrder(res)

--- a/test/kubernetes/axfr_test.go
+++ b/test/kubernetes/axfr_test.go
@@ -92,7 +92,7 @@ _c-port._udp.headless-svc.test-4.svc.cluster.local. 5 IN SRV 0 50 1234 headless-
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if res != nil {
 				failures := ValidateAXFR(res.Answer, tc.Answer)
@@ -161,7 +161,7 @@ cluster.local.		5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1726233
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if res != nil {
 				failures := ValidateAXFR(res.Answer, tc.Answer)

--- a/test/kubernetes/endpoints_test.go
+++ b/test/kubernetes/endpoints_test.go
@@ -57,7 +57,7 @@ func TestKubernetesEndpointPodNames(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", expected.Qname, dns.TypeToString[expected.Qtype]), func(t *testing.T) {
 			result, err := DoIntegrationTest(expected.Case, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 
 			if len(result.Answer) != expected.AnswerCount {

--- a/test/kubernetes/fallthrough_test.go
+++ b/test/kubernetes/fallthrough_test.go
@@ -83,7 +83,7 @@ func TestKubernetesFallthrough(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {
@@ -144,7 +144,7 @@ func TestKubernetesFallthroughFiltered(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {

--- a/test/kubernetes/nsexposure_test.go
+++ b/test/kubernetes/nsexposure_test.go
@@ -50,7 +50,7 @@ func TestKubernetesNSExposed(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {

--- a/test/kubernetes/pods_test.go
+++ b/test/kubernetes/pods_test.go
@@ -53,7 +53,7 @@ func TestKubernetesPodsInsecure(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {
@@ -110,7 +110,7 @@ func TestKubernetesPodsVerified(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {

--- a/test/kubernetes/ptr_test.go
+++ b/test/kubernetes/ptr_test.go
@@ -80,7 +80,7 @@ func TestKubernetesPTR(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {

--- a/test/kubernetes/srv_test.go
+++ b/test/kubernetes/srv_test.go
@@ -61,7 +61,7 @@ func TestKubernetesSRV(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			if err := test.SortAndCheck(res, tc); err != nil {

--- a/test/kubernetes/tools.go
+++ b/test/kubernetes/tools.go
@@ -76,7 +76,7 @@ func DoIntegrationTests(t *testing.T, testCases []test.Case, namespace string) {
 		t.Run(fmt.Sprintf("%s %s", tc.Qname, dns.TypeToString[tc.Qtype]), func(t *testing.T) {
 			res, err := DoIntegrationTest(tc, namespace)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			test.CNAMEOrder(res)
 			sort.Sort(test.RRSet(tc.Answer))
@@ -433,7 +433,7 @@ func ParseDigAXFR(s *bufio.Scanner) (*dns.Msg, error) {
 		m.Answer = append(m.Answer, r)
 	}
 	if len(m.Answer) == 0 {
-		return nil, fmt.Errorf("no more records")
+		return nil, errors.New("no more records")
 	}
 	return m, nil
 }

--- a/test/metadata_edns0/metadata_edns0_test.go
+++ b/test/metadata_edns0/metadata_edns0_test.go
@@ -52,7 +52,7 @@ func TestMetadata(t *testing.T) {
 
 		tries -= 1
 		if tries == 0 {
-			t.Errorf("Failed to get logs")
+			t.Error("Failed to get logs")
 		}
 		time.Sleep(500 * time.Millisecond)
 		logged = kubernetes.CorednsLogs()


### PR DESCRIPTION
fix format string funcs with missing format strings.

ALSO (UNRELATED)... remove test cases from the default k8s coredns config deployment tests that depend on external dns servers.  Two test cases relied on getting responses from upstream dns servers - one referring to example.net, which now returns 4 A records instead of 1.  Rather than update the test expectation to 4, I'm just removing these since they are kludgey.
