### PR TITLE
chore: `k8s_setup.sh` should use `kubectl wait`

### DIFF
--- a/build/kubernetes/k8s_setup.sh
+++ b/build/kubernetes/k8s_setup.sh
@@ -11,10 +11,7 @@ curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND
 kind create cluster --image kindest/node:${K8S_VERSION}
 
 # Wait for cluster to be ready
-JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}';
-until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
-  sleep 1;
-done
+kubectl wait --for=condition=Ready nodes --all --timeout=60s >/dev/null 2>&1
 
 # Scale the CoreDNS replicas to simplify testing
 kubectl scale -n kube-system deployment/coredns --replicas=1


### PR DESCRIPTION
It's been over 5 years since the current logic to wait on clusters was contributed. Better to use `kubectl wait` now (_originally [suggested here](https://github.com/coredns/ci/pull/161/files#r2506156892)_).

This will also better convey failure when `kubectl` is not a valid binary (_[example](https://github.com/coredns/coredns/pull/7659#issuecomment-3505374573)_).

---

Given the script hasn't been updated in over 5 years however, I'm not sure how relevant the `clusterroles` patch is now? (_I lack familiarity with how to go about checking if that has changed since_)