### PR TITLE
test/kubernetes/endpoints_test.go: fail test on no result to avoid panic

### DIFF
--- a/test/k8sdeployment/configmap_test.go
+++ b/test/k8sdeployment/configmap_test.go
@@ -73,7 +73,7 @@ my.cluster.local:53 {
 	}
 
 	if strings.Compare(corefileTranslated, corefileExpected) != 0 {
-		t.Fatalf("failed test: Translation does not match.\nGOT:\n" + corefileTranslated + "\n\nEXPECTED:\n" + corefileExpected)
+		t.Fatalf("failed test: Translation does not match.\nGOT:\n%s\n\nEXPECTED:\n%s", corefileTranslated, corefileExpected)
 	}
 
 	// Clean-up by removing kube-dns ConfigMap

--- a/test/kubernetai/autopath_test.go
+++ b/test/kubernetai/autopath_test.go
@@ -79,7 +79,6 @@ var autopathTests = []test.Case{
 }
 
 func TestKubernetesAutopath(t *testing.T) {
-
 	// set up server to handle internal zone, to trap *.internal search path in travis environment.
 	internal := `; internal zone info for autopath tests
 internal.		IN	SOA	sns.internal. noc.internal. 2015082541 7200 3600 1209600 3600
@@ -88,8 +87,7 @@ internal.		IN	SOA	sns.internal. noc.internal. 2015082541 7200 3600 1209600 3600
 	defer upstream.Stop()
 	defer rmFunc()
 
-	corefile :=
-		`    .:53 {
+	corefile := `    .:53 {
         health
         ready
         errors
@@ -126,7 +124,7 @@ internal.		IN	SOA	sns.internal. noc.internal. 2015082541 7200 3600 1209600 3600
 	}
 	err = kubernetes.WaitForClientPodRecord(namespace)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	for _, tc := range testCases {

--- a/test/kubernetes/endpoints_test.go
+++ b/test/kubernetes/endpoints_test.go
@@ -57,7 +57,7 @@ func TestKubernetesEndpointPodNames(t *testing.T) {
 		t.Run(fmt.Sprintf("%s %s", expected.Qname, dns.TypeToString[expected.Qtype]), func(t *testing.T) {
 			result, err := DoIntegrationTest(expected.Case, namespace)
 			if err != nil {
-				t.Error(err.Error())
+				t.Fatal(err.Error())
 			}
 
 			if len(result.Answer) != expected.AnswerCount {


### PR DESCRIPTION
Otherwise, following assertions will panic when result is nil.