### PR TITLE
fix(kubernetes): look up headless_with_selector metric by label in e2e test

### DIFF
--- a/test/kubernetes/metrics_test.go
+++ b/test/kubernetes/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	api "k8s.io/api/core/v1"
@@ -121,9 +122,11 @@ func testEndpoints(t *testing.T, client *kubernetes.Clientset, slices bool) {
 		expectBucketsDelta = map[int]uint64{}
 	}
 
-	// create the expected bucket values by adding deltas to the base state buckets
-	if _, ok := base[metricName]; ok {
-		for i, bucket := range base[metricName].Metric[0].Histogram.Bucket {
+	// create the expected bucket values by adding deltas to the base state buckets.
+	// Look up headless_with_selector explicitly — cluster_ip is now also recorded and
+	// sorts first alphabetically, so Metric[0] is no longer reliable.
+	if baseMetric := metricByServiceKind(base[metricName], "headless_with_selector"); baseMetric != nil {
+		for i, bucket := range baseMetric.Histogram.Bucket {
 			expectBuckets = append(expectBuckets, expectBucket{i, *bucket.CumulativeCount + expectBucketsDelta[i]})
 		}
 	}
@@ -138,12 +141,32 @@ func testEndpoints(t *testing.T, client *kubernetes.Clientset, slices bool) {
 	if _, ok := got[metricName]; !ok {
 		t.Fatalf("Did not find '%v' in scraped metrics.", metricName)
 	}
+	gotMetric := metricByServiceKind(got[metricName], "headless_with_selector")
+	if gotMetric == nil {
+		t.Fatalf("Did not find headless_with_selector service_kind in '%v'", metricName)
+	}
 	for _, eb := range expectBuckets {
-		count := *got[metricName].Metric[0].Histogram.Bucket[eb.n].CumulativeCount
+		count := *gotMetric.Histogram.Bucket[eb.n].CumulativeCount
 		if count != eb.count {
 			t.Errorf("In bucket %v, expected %v, got %v", eb.n, eb.count, count)
 		}
 	}
+}
+
+// metricByServiceKind returns the first dto.Metric in the family whose
+// service_kind label matches the given value, or nil if not found.
+func metricByServiceKind(family *dto.MetricFamily, serviceKind string) *dto.Metric {
+	if family == nil {
+		return nil
+	}
+	for _, m := range family.Metric {
+		for _, l := range m.Label {
+			if l.GetName() == "service_kind" && l.GetValue() == serviceKind {
+				return m
+			}
+		}
+	}
+	return nil
 }
 
 func addUpdateEndpoints(t *testing.T, client *kubernetes.Clientset) {


### PR DESCRIPTION
Companion fix for coredns/coredns#7951, which extends `coredns_kubernetes_dns_programming_duration_seconds` to record `cluster_ip` services in addition to `headless_with_selector`.

**Problem:** `TestDNSProgrammingLatencyEndpoints` selected the histogram to check via `Metric[0]`. Before #7951, only `headless_with_selector` was ever emitted, so `Metric[0]` was always that series. After #7951, `cluster_ip` is also emitted and sorts alphabetically before `headless_with_selector`, so `Metric[0]` changed, causing the expected delta check to fail.

**Fix:** Extract a `metricByServiceKind` helper that finds the correct `*dto.Metric` by its `service_kind` label value, and use it to select `headless_with_selector` explicitly in both the base and final scrape comparisons.