### PR TITLE
test/kubernetes: use zero-value TextParser until prometheus/common is bumped

### DIFF
--- a/test/kubernetes/metrics_test.go
+++ b/test/kubernetes/metrics_test.go
@@ -10,7 +10,6 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
 	api "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,7 +84,11 @@ func testEndpoints(t *testing.T, client *kubernetes.Clientset, slices bool) {
 
 	// scrape and parse metrics to get base state
 	m := ScrapeMetrics(t)
-	tp := expfmt.NewTextParser(model.LegacyValidation)
+	// prometheus/common v0.59.1 (pinned in go.mod) does not yet expose
+	// NewTextParser; stick with the zero-value TextParser, which
+	// defaults to legacy validation, until coredns/coredns#7731 bumps
+	// the common dep.
+	var tp expfmt.TextParser
 	base, err := tp.TextToMetricFamilies(strings.NewReader(string(m)))
 	if err != nil {
 		t.Fatalf("Could not parse scraped metrics: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

`expfmt.NewTextParser` was introduced in a later `prometheus/common` release than the one pinned here (`v0.59.1`), so every CoreDNS PR that runs the Kubernetes test step fails with:

```
./metrics_test.go:87:15: undefined: expfmt.NewTextParser
```

(reported against [coredns/coredns#7731](https://github.com/coredns/coredns/issues/7731) - e.g. the Circle-CI failure on [coredns/coredns#7728](https://github.com/coredns/coredns/pull/7728)).

Revert that call site to the zero-value `var tp expfmt.TextParser` pattern (which defaults to legacy validation) so the job compiles on the currently pinned dependency. Once `go.mod`'s `prometheus/common` is bumped to a version that exports `NewTextParser`, this can be re-applied without the compat note.

Also drops the now-unused `prometheus/common/model` import.

**Release note**:
```release-note
NONE
```
